### PR TITLE
Adding outlook and slack connectors

### DIFF
--- a/apps/app-config/connectors/connectors.def.ts
+++ b/apps/app-config/connectors/connectors.def.ts
@@ -31,6 +31,7 @@ import {default as connectorRevert} from '@openint/connector-revert/def'
 import {default as connectorSalesforce} from '@openint/connector-salesforce/def'
 import {default as connectorSalesloft} from '@openint/connector-salesloft/def'
 import {default as connectorSaltedge} from '@openint/connector-saltedge/def'
+import {default as connectorSlack} from '@openint/connector-slack/def'
 import {default as connectorSplitwise} from '@openint/connector-splitwise/def'
 import {default as connectorSpreadsheet} from '@openint/connector-spreadsheet/def'
 import {default as connectorStripe} from '@openint/connector-stripe/def'
@@ -76,6 +77,7 @@ export const defConnectors = {
   salesforce: connectorSalesforce,
   salesloft: connectorSalesloft,
   saltedge: connectorSaltedge,
+  slack: connectorSlack,
   splitwise: connectorSplitwise,
   spreadsheet: connectorSpreadsheet,
   stripe: connectorStripe,

--- a/apps/app-config/connectors/connectors.def.ts
+++ b/apps/app-config/connectors/connectors.def.ts
@@ -21,6 +21,7 @@ import {default as connectorMerge} from '@openint/connector-merge/def'
 import {default as connectorMongodb} from '@openint/connector-mongodb/def'
 import {default as connectorMoota} from '@openint/connector-moota/def'
 import {default as connectorOnebrick} from '@openint/connector-onebrick/def'
+import {default as connectorOutlook} from '@openint/connector-outlook/def'
 import {default as connectorOutreach} from '@openint/connector-outreach/def'
 import {default as connectorPipedrive} from '@openint/connector-pipedrive/def'
 import {default as connectorPlaid} from '@openint/connector-plaid/def'
@@ -67,6 +68,7 @@ export const defConnectors = {
   mongodb: connectorMongodb,
   moota: connectorMoota,
   onebrick: connectorOnebrick,
+  outlook: connectorOutlook,
   outreach: connectorOutreach,
   pipedrive: connectorPipedrive,
   plaid: connectorPlaid,

--- a/apps/app-config/connectors/connectors.merged.ts
+++ b/apps/app-config/connectors/connectors.merged.ts
@@ -62,6 +62,8 @@ import {default as connectorSalesloft_def} from '@openint/connector-salesloft/de
 import {default as connectorSalesloft_server} from '@openint/connector-salesloft/server'
 import {default as connectorSaltedge_def} from '@openint/connector-saltedge/def'
 import {default as connectorSaltedge_server} from '@openint/connector-saltedge/server'
+import {default as connectorSlack_def} from '@openint/connector-slack/def'
+import {default as connectorSlack_server} from '@openint/connector-slack/server'
 import {default as connectorSplitwise_def} from '@openint/connector-splitwise/def'
 import {default as connectorSplitwise_server} from '@openint/connector-splitwise/server'
 import {default as connectorSpreadsheet_def} from '@openint/connector-spreadsheet/def'
@@ -243,6 +245,11 @@ const connectorSaltedge = {
   ...connectorSaltedge_server,
 }
 
+const connectorSlack = {
+  ...connectorSlack_def,
+  ...connectorSlack_server,
+}
+
 const connectorSplitwise = {
   ...connectorSplitwise_def,
   ...connectorSplitwise_server,
@@ -330,6 +337,7 @@ export const mergedConnectors = {
   salesforce: connectorSalesforce,
   salesloft: connectorSalesloft,
   saltedge: connectorSaltedge,
+  slack: connectorSlack,
   splitwise: connectorSplitwise,
   spreadsheet: connectorSpreadsheet,
   stripe: connectorStripe,

--- a/apps/app-config/connectors/connectors.merged.ts
+++ b/apps/app-config/connectors/connectors.merged.ts
@@ -42,6 +42,8 @@ import {default as connectorMoota_def} from '@openint/connector-moota/def'
 import {default as connectorMoota_server} from '@openint/connector-moota/server'
 import {default as connectorOnebrick_def} from '@openint/connector-onebrick/def'
 import {default as connectorOnebrick_server} from '@openint/connector-onebrick/server'
+import {default as connectorOutlook_def} from '@openint/connector-outlook/def'
+import {default as connectorOutlook_server} from '@openint/connector-outlook/server'
 import {default as connectorOutreach_def} from '@openint/connector-outreach/def'
 import {default as connectorOutreach_server} from '@openint/connector-outreach/server'
 import {default as connectorPipedrive_def} from '@openint/connector-pipedrive/def'
@@ -195,6 +197,11 @@ const connectorOnebrick = {
   ...connectorOnebrick_server,
 }
 
+const connectorOutlook = {
+  ...connectorOutlook_def,
+  ...connectorOutlook_server,
+}
+
 const connectorOutreach = {
   ...connectorOutreach_def,
   ...connectorOutreach_server,
@@ -327,6 +334,7 @@ export const mergedConnectors = {
   mongodb: connectorMongodb,
   moota: connectorMoota,
   onebrick: connectorOnebrick,
+  outlook: connectorOutlook,
   outreach: connectorOutreach,
   pipedrive: connectorPipedrive,
   plaid: connectorPlaid,

--- a/apps/app-config/connectors/connectors.server.ts
+++ b/apps/app-config/connectors/connectors.server.ts
@@ -20,6 +20,7 @@ import {default as connectorMerge} from '@openint/connector-merge/server'
 import {default as connectorMongodb} from '@openint/connector-mongodb/server'
 import {default as connectorMoota} from '@openint/connector-moota/server'
 import {default as connectorOnebrick} from '@openint/connector-onebrick/server'
+import {default as connectorOutlook} from '@openint/connector-outlook/server'
 import {default as connectorOutreach} from '@openint/connector-outreach/server'
 import {default as connectorPipedrive} from '@openint/connector-pipedrive/server'
 import {default as connectorPlaid} from '@openint/connector-plaid/server'
@@ -64,6 +65,7 @@ export const serverConnectors = {
   mongodb: connectorMongodb,
   moota: connectorMoota,
   onebrick: connectorOnebrick,
+  outlook: connectorOutlook,
   outreach: connectorOutreach,
   pipedrive: connectorPipedrive,
   plaid: connectorPlaid,

--- a/apps/app-config/connectors/connectors.server.ts
+++ b/apps/app-config/connectors/connectors.server.ts
@@ -30,6 +30,7 @@ import {default as connectorRevert} from '@openint/connector-revert/server'
 import {default as connectorSalesforce} from '@openint/connector-salesforce/server'
 import {default as connectorSalesloft} from '@openint/connector-salesloft/server'
 import {default as connectorSaltedge} from '@openint/connector-saltedge/server'
+import {default as connectorSlack} from '@openint/connector-slack/server'
 import {default as connectorSplitwise} from '@openint/connector-splitwise/server'
 import {default as connectorSpreadsheet} from '@openint/connector-spreadsheet/server'
 import {default as connectorStripe} from '@openint/connector-stripe/server'
@@ -73,6 +74,7 @@ export const serverConnectors = {
   salesforce: connectorSalesforce,
   salesloft: connectorSalesloft,
   saltedge: connectorSaltedge,
+  slack: connectorSlack,
   splitwise: connectorSplitwise,
   spreadsheet: connectorSpreadsheet,
   stripe: connectorStripe,

--- a/apps/app-config/connectors/meta.js
+++ b/apps/app-config/connectors/meta.js
@@ -298,6 +298,15 @@ module.exports = [
     },
   },
   {
+    name: 'slack',
+    dirName: 'connector-slack',
+    varName: 'connectorSlack',
+    imports: {
+      def: '@openint/connector-slack/def',
+      server: '@openint/connector-slack/server',
+    },
+  },
+  {
     name: 'splitwise',
     dirName: 'connector-splitwise',
     varName: 'connectorSplitwise',

--- a/apps/app-config/connectors/meta.js
+++ b/apps/app-config/connectors/meta.js
@@ -207,6 +207,15 @@ module.exports = [
     },
   },
   {
+    name: 'outlook',
+    dirName: 'connector-outlook',
+    varName: 'connectorOutlook',
+    imports: {
+      def: '@openint/connector-outlook/def',
+      server: '@openint/connector-outlook/server',
+    },
+  },
+  {
     name: 'outreach',
     dirName: 'connector-outreach',
     varName: 'connectorOutreach',

--- a/apps/app-config/package.json
+++ b/apps/app-config/package.json
@@ -36,6 +36,7 @@
     "@openint/connector-mongodb": "workspace:*",
     "@openint/connector-moota": "workspace:*",
     "@openint/connector-onebrick": "workspace:*",
+    "@openint/connector-outlook": "workspace:*",
     "@openint/connector-outreach": "workspace:*",
     "@openint/connector-pipedrive": "workspace:*",
     "@openint/connector-plaid": "workspace:*",

--- a/apps/app-config/package.json
+++ b/apps/app-config/package.json
@@ -46,6 +46,7 @@
     "@openint/connector-salesforce": "workspace:*",
     "@openint/connector-salesloft": "workspace:*",
     "@openint/connector-saltedge": "workspace:*",
+    "@openint/connector-slack": "workspace:*",
     "@openint/connector-splitwise": "workspace:*",
     "@openint/connector-spreadsheet": "workspace:*",
     "@openint/connector-stripe": "workspace:*",

--- a/connectors/connector-outlook/def.ts
+++ b/connectors/connector-outlook/def.ts
@@ -1,0 +1,33 @@
+import type {ConnectorDef, ConnectorSchemas} from '@openint/cdk'
+import {connHelpers, oauthBaseSchema} from '@openint/cdk'
+import {z} from '@openint/util'
+
+export const zConfig = oauthBaseSchema.connectorConfig
+
+const oReso = oauthBaseSchema.resourceSettings
+export const zSettings = oReso.extend({
+  oauth: oReso.shape.oauth,
+})
+
+export const outlookSchemas = {
+  name: z.literal('outlook'),
+  connectorConfig: zConfig,
+  resourceSettings: zSettings,
+  connectOutput: oauthBaseSchema.connectOutput,
+} satisfies ConnectorSchemas
+
+export const outlookHelpers = connHelpers(outlookSchemas)
+
+export const outlookDef = {
+  name: 'outlook',
+  schemas: outlookSchemas,
+  metadata: {
+    displayName: 'outlook',
+    stage: 'beta',
+    verticals: ['other'],
+    logoUrl: '/_assets/logo-outlook.svg',
+    nangoProvider: 'outlook',
+  },
+} satisfies ConnectorDef<typeof outlookSchemas>
+
+export default outlookDef

--- a/connectors/connector-outlook/def.ts
+++ b/connectors/connector-outlook/def.ts
@@ -26,7 +26,8 @@ export const outlookDef = {
     stage: 'beta',
     verticals: ['other'],
     logoUrl: '/_assets/logo-outlook.svg',
-    nangoProvider: 'outlook',
+    // TODO: update  nango SDK version to support outlook key
+    nangoProvider: 'outlook' as any,
   },
 } satisfies ConnectorDef<typeof outlookSchemas>
 

--- a/connectors/connector-outlook/index.ts
+++ b/connectors/connector-outlook/index.ts
@@ -1,0 +1,4 @@
+// codegen:start {preset: barrel, include: "./{*.{ts,tsx},*/index.{ts,tsx}}", exclude: "./**/*.{d,spec,test,fixture,gen,node}.{ts,tsx}"}
+export * from './def'
+export * from './server'
+// codegen:end

--- a/connectors/connector-outlook/package.json
+++ b/connectors/connector-outlook/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openint/connector-outlook",
+  "version": "0.0.0",
+  "private": true,
+  "module": "./index.ts",
+  "dependencies": {
+    "@openint/cdk": "workspace:*",
+    "@openint/util": "workspace:*",
+    "@openint/vdk": "workspace:*",
+    "@opensdks/runtime": "^0.0.19"
+  },
+  "devDependencies": {}
+}

--- a/connectors/connector-outlook/server.ts
+++ b/connectors/connector-outlook/server.ts
@@ -1,0 +1,30 @@
+import {extractId, initNangoSDK, type ConnectorServer} from '@openint/cdk'
+import type {outlookSchemas} from './def'
+
+export const outlookServer = {
+  postConnect: async (connectOutput) => {
+    const nango = initNangoSDK({
+      headers: {authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`},
+    })
+    const nangoConnection = await nango
+      .GET('/connection/{connectionId}', {
+        params: {
+          path: {connectionId: connectOutput.connectionId},
+          query: {
+            provider_config_key: connectOutput.providerConfigKey,
+          },
+        },
+      })
+      .then((r) => r.data as {credentials: {access_token: string}})
+
+    return {
+      resourceExternalId: extractId(connectOutput.connectionId)[2],
+      settings: {
+        oauth: nangoConnection,
+      },
+      triggerDefaultSync: true,
+    }
+  },
+} satisfies ConnectorServer<typeof outlookSchemas>
+
+export default outlookServer

--- a/connectors/connector-salesforce/server.ts
+++ b/connectors/connector-salesforce/server.ts
@@ -15,12 +15,7 @@ export const salesforceServer = {
     return sdk
   },
 
-  postConnect: async (connectOutput, config, context) => {
-    console.log('salesforce postConnect input:', {
-      connectOutput,
-      config,
-      context,
-    })
+  postConnect: async (connectOutput) => {
     const nango = initNangoSDK({
       headers: {authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`},
     })

--- a/connectors/connector-slack/def.ts
+++ b/connectors/connector-slack/def.ts
@@ -1,0 +1,33 @@
+import type {ConnectorDef, ConnectorSchemas} from '@openint/cdk'
+import {connHelpers, oauthBaseSchema} from '@openint/cdk'
+import {z} from '@openint/util'
+
+export const zConfig = oauthBaseSchema.connectorConfig
+
+const oReso = oauthBaseSchema.resourceSettings
+export const zSettings = oReso.extend({
+  oauth: oReso.shape.oauth,
+})
+
+export const slackSchemas = {
+  name: z.literal('slack'),
+  connectorConfig: zConfig,
+  resourceSettings: zSettings,
+  connectOutput: oauthBaseSchema.connectOutput,
+} satisfies ConnectorSchemas
+
+export const slackHelpers = connHelpers(slackSchemas)
+
+export const slackDef = {
+  name: 'slack',
+  schemas: slackSchemas,
+  metadata: {
+    displayName: 'slack',
+    stage: 'beta',
+    verticals: ['other'],
+    logoUrl: '/_assets/logo-slack.svg',
+    nangoProvider: 'slack',
+  },
+} satisfies ConnectorDef<typeof slackSchemas>
+
+export default slackDef

--- a/connectors/connector-slack/index.ts
+++ b/connectors/connector-slack/index.ts
@@ -1,0 +1,4 @@
+// codegen:start {preset: barrel, include: "./{*.{ts,tsx},*/index.{ts,tsx}}", exclude: "./**/*.{d,spec,test,fixture,gen,node}.{ts,tsx}"}
+export * from './def'
+export * from './server'
+// codegen:end

--- a/connectors/connector-slack/package.json
+++ b/connectors/connector-slack/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@openint/connector-slack",
+  "version": "0.0.0",
+  "private": true,
+  "module": "./index.ts",
+  "dependencies": {
+    "@openint/cdk": "workspace:*",
+    "@openint/util": "workspace:*",
+    "@openint/vdk": "workspace:*",
+    "@opensdks/runtime": "^0.0.19"
+  },
+  "devDependencies": {}
+}

--- a/connectors/connector-slack/server.ts
+++ b/connectors/connector-slack/server.ts
@@ -1,0 +1,30 @@
+import {extractId, initNangoSDK, type ConnectorServer} from '@openint/cdk'
+import type {slackSchemas} from './def'
+
+export const slackServer = {
+  postConnect: async (connectOutput) => {
+    const nango = initNangoSDK({
+      headers: {authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`},
+    })
+    const nangoConnection = await nango
+      .GET('/connection/{connectionId}', {
+        params: {
+          path: {connectionId: connectOutput.connectionId},
+          query: {
+            provider_config_key: connectOutput.providerConfigKey,
+          },
+        },
+      })
+      .then((r) => r.data as {credentials: {access_token: string}})
+
+    return {
+      resourceExternalId: extractId(connectOutput.connectionId)[2],
+      settings: {
+        oauth: nangoConnection,
+      },
+      triggerDefaultSync: true,
+    }
+  },
+} satisfies ConnectorServer<typeof slackSchemas>
+
+export default slackServer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@openint/connector-onebrick':
         specifier: workspace:*
         version: link:../../connectors/connector-onebrick
+      '@openint/connector-outlook':
+        specifier: workspace:*
+        version: link:../../connectors/connector-outlook
       '@openint/connector-outreach':
         specifier: workspace:*
         version: link:../../connectors/connector-outreach
@@ -984,6 +987,21 @@ importers:
       '@types/react':
         specifier: 18.0.27
         version: 18.0.27
+
+  connectors/connector-outlook:
+    dependencies:
+      '@openint/cdk':
+        specifier: workspace:*
+        version: link:../../kits/cdk
+      '@openint/util':
+        specifier: workspace:*
+        version: link:../../packages/util
+      '@openint/vdk':
+        specifier: workspace:*
+        version: link:../../kits/vdk
+      '@opensdks/runtime':
+        specifier: ^0.0.19
+        version: 0.0.19
 
   connectors/connector-outreach:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@openint/connector-saltedge':
         specifier: workspace:*
         version: link:../../connectors/connector-saltedge
+      '@openint/connector-slack':
+        specifier: workspace:*
+        version: link:../../connectors/connector-slack
       '@openint/connector-splitwise':
         specifier: workspace:*
         version: link:../../connectors/connector-splitwise
@@ -1166,6 +1169,21 @@ importers:
       '@openint/util':
         specifier: workspace:*
         version: link:../../packages/util
+
+  connectors/connector-slack:
+    dependencies:
+      '@openint/cdk':
+        specifier: workspace:*
+        version: link:../../kits/cdk
+      '@openint/util':
+        specifier: workspace:*
+        version: link:../../packages/util
+      '@openint/vdk':
+        specifier: workspace:*
+        version: link:../../kits/vdk
+      '@opensdks/runtime':
+        specifier: ^0.0.19
+        version: 0.0.19
 
   connectors/connector-splitwise:
     dependencies:
@@ -20788,7 +20806,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.23.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0)(eslint@8.23.0))(eslint@8.23.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.23.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3)(eslint@8.23.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -20833,7 +20851,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.23.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0)(eslint@8.23.0))(eslint@8.23.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.23.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3)(eslint@8.23.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
Steps to create a basic connector

- [ ] Create a base package by cloning a simple one like connector-slack and replacing 'slack' with new app name on all files (def, server and package.json)
- [ ] Ensure that you add the SVG logo file to apps/web/public/_assets
- [ ] Add to `apps/apps-config/package.json` as dependency
- [ ] Run `pnpm install & pnpm prune && pnpm generate:connectorsList`
- [ ] Run `pnpm run lint && pnpm run typecheck` and ensure that lints pass 