### PR TITLE
Hide pg default in ccfgs and resources pages

### DIFF
--- a/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
+++ b/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
@@ -33,6 +33,9 @@ export default function ConnectorConfigsPage({
     return <LoadingText className="block p-4" />
   }
 
+  const filter = (c: ConnectorConfig) =>
+    c.displayName !== 'Default Postgres Connector for sync'
+
   return (
     <div className="max-w-[60%] p-6">
       <h2 className="mb-4 text-2xl font-semibold tracking-tight">
@@ -44,6 +47,7 @@ export default function ConnectorConfigsPage({
       {connectorConfigsRes.data ? (
         <DataTable
           query={connectorConfigsRes}
+          filter={filter}
           columns={[
             {
               id: 'connectorName',

--- a/apps/web/app/dashboard/(authenticated)/resources/ResourcesPage.tsx
+++ b/apps/web/app/dashboard/(authenticated)/resources/ResourcesPage.tsx
@@ -9,6 +9,8 @@ import {VCommandMenu} from '@/vcommands/vcommand-components'
 
 export default function ResourcesPage() {
   const res = _trpcReact.listConnections.useQuery({})
+  const filter = (c: {id: string}) => !c.id.includes('postgres_default')
+
   return (
     <div className="p-6">
       <header className="flex items-center">
@@ -20,6 +22,7 @@ export default function ResourcesPage() {
       <p>Resources are created based on connector configurations</p>
       <DataTable
         query={res}
+        filter={filter}
         columns={[
           {
             id: 'actions',

--- a/packages/ui/components/DataTable.tsx
+++ b/packages/ui/components/DataTable.tsx
@@ -35,10 +35,13 @@ import {
 } from '../shadcn'
 import {LoadingText} from './LoadingText'
 
+const defaultFilter = () => true
+
 interface DataTableProps<TData, TValue> {
   query: UseQueryResult<TData[]>
   columns: Array<ColumnDef<TData, TValue>>
   enableSelect?: boolean
+  filter?: (data: TData) => boolean
 }
 
 // TODO: Create a schemaDataTable that define columns based on zod schema
@@ -47,6 +50,7 @@ export function DataTable<TData, TValue>({
   columns: _columns,
   query,
   enableSelect,
+  filter = defaultFilter,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -191,20 +195,23 @@ export function DataTable<TData, TValue>({
                 </TableCell>
               </TableRow>
             ) : (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && 'selected'}>
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
+              table
+                .getRowModel()
+                .rows.filter((row) => filter(row.original))
+                .map((row) => (
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && 'selected'}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
             )}
           </TableBody>
         </Table>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds filtering to hide default Postgres connectors in `ConnectorConfigPage.tsx` and `ResourcesPage.tsx`.
> 
>   - **Behavior**:
>     - Hides default Postgres connectors in `ConnectorConfigPage.tsx` and `ResourcesPage.tsx` by filtering out entries with specific identifiers.
>   - **Components**:
>     - Adds `filter` prop to `DataTable` in `DataTable.tsx` to allow custom row filtering.
>     - Applies `filter` function in `ConnectorConfigPage.tsx` to exclude connectors with `displayName` 'Default Postgres Connector for sync'.
>     - Applies `filter` function in `ResourcesPage.tsx` to exclude resources with `id` containing 'postgres_default'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 17e7064d8e0a13268adca4f054b7ad38ec7d99cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->