### PR TITLE
deleted focus animation on specific schemaform and onhover connectorcard fix

### DIFF
--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -240,4 +240,8 @@
   .form-group:has(> select) + .field > label {
     display: none;
   }
+
+  .schema-form input[type='number'] {
+    @apply flex h-10 w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50;
+  }
 }

--- a/packages/ui/domain-components/ConnectorCard.tsx
+++ b/packages/ui/domain-components/ConnectorCard.tsx
@@ -72,7 +72,7 @@ export const ConnectorCard = ({
         'relative m-3 flex h-[150px] w-[150px] flex-col items-center justify-center p-2',
         'border border-gray-300',
         'transition duration-300 ease-in-out',
-        isHovered ? 'border-button bg-white' : '',
+        isHovered ? 'border-button bg-[#F8F7FF]' : '',
         className,
       )}
       onMouseEnter={() => setIsHovered(true)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove focus animation from `.schema-form input[type='number']` and update hover background color for `ConnectorCard`.
> 
>   - **CSS Changes**:
>     - Removed focus animation for `.schema-form input[type='number']` in `global.css`.
>   - **UI Changes**:
>     - Updated hover background color to `#F8F7FF` for `ConnectorCard` in `ConnectorCard.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for f3b90fd4effd6c30abf1e43269f4fd999f5c74a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->