### PR TITLE
Hide pipeline runs in prod, refetch ccfgs after upsert/delete and update DataTable loader.

### DIFF
--- a/apps/web/app/dashboard/(authenticated)/Sidebar.tsx
+++ b/apps/web/app/dashboard/(authenticated)/Sidebar.tsx
@@ -14,6 +14,16 @@ interface LinkItem {
   icon?: IconName
 }
 
+const devSectionedLinks: LinkItem[] = __DEBUG__
+  ? [
+      {
+        title: 'Pipeline Runs',
+        href: '/dashboard/pipeline-runs',
+        icon: 'ArrowLeftRight',
+      },
+    ]
+  : []
+
 const sectionedLinks: Array<{
   title?: string
   items: LinkItem[]
@@ -65,21 +75,12 @@ const sectionedLinks: Array<{
         href: '/dashboard/connector-configs',
         icon: 'Layers',
       },
-    ],
-  },
-  {
-    title: 'Pipelines',
-    items: [
       {
-        title: 'Pipeline List',
+        title: 'Pipelines',
         href: '/dashboard/pipelines',
         icon: 'ArrowLeftRight',
       },
-      {
-        title: 'Pipeline Runs',
-        href: '/dashboard/pipeline-runs',
-        icon: 'ArrowLeftRight',
-      },
+      ...devSectionedLinks,
     ],
   },
   {

--- a/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
+++ b/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
@@ -61,9 +61,6 @@ export default function ConnectorConfigsPage({
       <h2 className="mb-4 text-2xl font-semibold tracking-tight">
         Configured connectors
       </h2>
-      {connectorConfigsRes.isFetching && (
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-      )}
       {connectorConfigsRes.data ? (
         <DataTable
           query={connectorConfigsRes}
@@ -212,6 +209,7 @@ export default function ConnectorConfigsPage({
         connectorConfig={connectorConfig}
         open={open}
         setOpen={setOpen}
+        refetch={connectorConfigsRes.refetch}
       />
       <CalendarBooking
         description="Grab some time with our founder to help you get the best out of OpenInt"

--- a/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigSheet.tsx
+++ b/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigSheet.tsx
@@ -38,11 +38,13 @@ export function ConnectorConfigSheet({
   connectorName,
   open,
   setOpen,
+  refetch,
 }: {
   connectorConfig?: Omit<ConnectorConfig, 'connectorName'>
   connectorName: string
   open: boolean
   setOpen: (open: boolean) => void
+  refetch?: () => void
 }) {
   const trpcUtils = _trpcReact.useContext()
   const connectorMetaRes = _trpcReact.getConnectorMeta.useQuery({
@@ -60,6 +62,7 @@ export function ConnectorConfigSheet({
         toast({title: 'connector config saved', variant: 'success'})
         void trpcUtils.adminListConnectorConfigs.invalidate()
         void trpcUtils.listConnectorConfigInfos.invalidate()
+        refetch?.()
       },
       onError: (err) => {
         toast({
@@ -76,6 +79,7 @@ export function ConnectorConfigSheet({
         toast({title: 'connector config deleted', variant: 'success'})
         void trpcUtils.adminListConnectorConfigs.invalidate()
         void trpcUtils.listConnectorConfigInfos.invalidate()
+        refetch?.()
       },
       onError: (err) => {
         toast({

--- a/packages/ui/components/DataTable.tsx
+++ b/packages/ui/components/DataTable.tsx
@@ -15,7 +15,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import {ChevronDown, Search} from 'lucide-react'
+import {ChevronDown, Loader2, Search} from 'lucide-react'
 import React from 'react'
 import {R, titleCase} from '@openint/util'
 import {
@@ -34,7 +34,6 @@ import {
   TableRow,
 } from '../shadcn'
 import {cn} from '../utils'
-import {LoadingText} from './LoadingText'
 
 const defaultFilter = () => true
 
@@ -189,7 +188,9 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center">
                   {query.isLoading || query.isRefetching ? (
-                    <LoadingText />
+                    <div className="flex size-full min-h-[300px] items-center justify-center">
+                      <Loader2 className="size-8 animate-spin text-button" />
+                    </div>
                   ) : query.isError ? (
                     `Error: ${query.error}`
                   ) : (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Hide 'Pipeline Runs' in production, refetch connector configurations after updates, and update `DataTable` loading indicator.
> 
>   - **UI Changes**:
>     - Hide 'Pipeline Runs' in production by using `__DEBUG__` flag in `Sidebar.tsx`.
>     - Update `DataTable.tsx` to replace `LoadingText` with a spinner for loading state.
>   - **Connector Configurations**:
>     - Add `refetch` function to `ConnectorConfigSheet.tsx` to refresh data after upsert/delete operations.
>     - Remove loader from `ConnectorConfigPage.tsx` when fetching connector configurations.
>   - **Misc**:
>     - Minor refactoring and cleanup in `ConnectorConfigPage.tsx` and `ConnectorConfigSheet.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 4111257a90a10dbbff6bbceaab2a1394d5a8eb3d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->