### PR TITLE
FS fixes

### DIFF
--- a/kits/cdk/internal/remote-procedure.ts
+++ b/kits/cdk/internal/remote-procedure.ts
@@ -28,7 +28,13 @@ export async function getRemoteContext(ctx: ProtectedContext) {
     ctx.remoteConnectionId,
   )
 
-  const connectionId = toNangoConnectionId(connection.id) // ctx.customerId
+  let connectionId = toNangoConnectionId(connection.id) // ctx.customerId
+
+  // Note: Monkey patch for old connections
+  if(connection.createdAt < new Date('2024-12-10')) {
+    connectionId = connectionId.replace('conn_', 'reso_')
+  }
+  
   const providerConfigKey = toNangoProviderConfigKey(
     connection.connectorConfigId, // ctx.providerName
   )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance Microsoft Graph adapter by fetching drives per site, removing `$filter` from queries, and correcting file listing endpoint.
> 
>   - **Behavior**:
>     - Fetch drives for each site in `listDrives` in `index.ts`, flatten responses, and update `items` to `allDrives`.
>     - Remove `$filter` query parameter from `listFolders` and `listFiles` in `index.ts`.
>     - Correct endpoint in `listFiles` to `/drives/{drive-id}/root/children` when `folderId` is not provided.
>   - **Misc**:
>     - Add `@ts-expect-error` comments for unsupported `$skiptoken` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 228e891480470d0c0529af2a58260c12a85f098e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->