### PR TITLE
removing duplicate filtering

### DIFF
--- a/packages/engine-backend/router/connectorRouter.ts
+++ b/packages/engine-backend/router/connectorRouter.ts
@@ -232,6 +232,7 @@ export const connectorRouter = trpc.mergeRouters(
                 }))
             }),
         )
+
         // TODO: Implement filtering in each of the connectors instead?
 
         // integration should have connector name...

--- a/packages/engine-frontend/components/ConnectIntegrations.tsx
+++ b/packages/engine-frontend/components/ConnectIntegrations.tsx
@@ -6,7 +6,6 @@ import {IntegrationSearch} from './IntegrationSearch'
 
 export function ConnectIntegrations({
   connectorConfigFilters,
-  connectorNames = [],
   enabledIntegrationIds = [],
   onEvent,
 }: {
@@ -18,13 +17,10 @@ export function ConnectIntegrations({
   return (
     <WithConnectConfig {...connectorConfigFilters}>
       {({ccfgs}) => {
-        const filteredCcfgs = ccfgs.filter(
-          (c) => !connectorNames.includes(c.connectorName),
-        )
 
         return (
           <IntegrationSearch
-            connectorConfigs={filteredCcfgs}
+            connectorConfigs={ccfgs}
             enabledIntegrationIds={enabledIntegrationIds}
             onEvent={(e) => {
               if (onEvent) onEvent(e)

--- a/packages/engine-frontend/components/ConnectionPortal.tsx
+++ b/packages/engine-frontend/components/ConnectionPortal.tsx
@@ -113,6 +113,7 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
           listConnectionsRes.isFetching ||
           listConnectionsRes.isRefetching
 
+          
         const enabledIntegrationIds: string[] =
           listConnectionsRes.data
             ?.filter((c): c is typeof c & {integration: {id: string}} =>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove duplicate filtering logic in `ConnectIntegrations` component and make minor formatting changes.
> 
>   - **Frontend**:
>     - Remove `connectorNames` prop and filtering logic from `ConnectIntegrations` in `ConnectIntegrations.tsx`.
>   - **Misc**:
>     - Minor formatting changes in `connectorRouter.ts` and `ConnectionPortal.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 9e3957be2fc2f6cdb8c8a4a79cbdf113c74805f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->