### PR TITLE
bookademo cta + hiding create pipelines button

### DIFF
--- a/apps/web/app/dashboard/(authenticated)/Sidebar.tsx
+++ b/apps/web/app/dashboard/(authenticated)/Sidebar.tsx
@@ -159,6 +159,14 @@ export function Sidebar({className, hasPgConnection}: SidebarProps) {
         </div>
       </ScrollArea>
       <div className="mt-auto p-4">
+      <Button 
+    variant="default" 
+    size="sm" 
+    className="w-full justify-center mb-4" 
+    onClick={() => window.open('https://cal.com/ap-openint/discovery', '_blank')}
+  >
+    Book A Demo
+  </Button>
         <Link
           className="flex flex-row items-center gap-2 font-semibold hover:opacity-90"
           href="/">

--- a/apps/web/app/dashboard/(authenticated)/pipelines/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/pipelines/page.tsx
@@ -2,7 +2,7 @@
 
 import {DataTable} from '@openint/ui'
 import {trpcReact} from '@/lib-client/trpcReact'
-import {VCommandButton, VCommandMenu} from '@/vcommands/vcommand-components'
+import {VCommandMenu} from '@/vcommands/vcommand-components'
 
 export default function PipelinesPage() {
   const res = trpcReact.listPipelines.useQuery()
@@ -15,7 +15,7 @@ export default function PipelinesPage() {
         <h2 className="mb-4 mr-auto text-2xl font-semibold tracking-tight">
           Pipelines
         </h2>
-        <VCommandButton command={['pipeline:create', {}]} />
+        {/* <VCommandButton command={['pipeline:create', {}]} /> */}
       </header>
       <p>
         Pipelines connect connections together by syncing data from source


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'Book A Demo' button to sidebar and hide 'Create Pipeline' button in pipelines page.
> 
>   - **UI Changes**:
>     - Add 'Book A Demo' button in `Sidebar.tsx` that opens `https://cal.com/ap-openint/discovery` in a new tab.
>     - Comment out 'Create Pipeline' button in `pipelines/page.tsx`, hiding it from the UI.
>   - **Imports**:
>     - Remove unused `VCommandButton` import from `pipelines/page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 7760b04087b3128a9ab5baddd3a377b3711044cd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->