### PR TITLE
Refetch data when org changes

### DIFF
--- a/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
+++ b/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@openint/ui'
 import CalendarBooking from '@openint/ui/components/CalendarBooking'
 import {inPlaceSort, R, titleCase} from '@openint/util'
+import useRefetchOnSwitch from '../useRefetchOnSwitch'
 import {ConnectorConfigSheet} from './ConnectorConfigSheet'
 
 const CTA_LINK = 'ap-openint/request-integration'
@@ -57,6 +58,8 @@ export default function ConnectorConfigsPage({
   })
   const {user} = useUser()
   const connectorConfigsRes = _trpcReact.adminListConnectorConfigs.useQuery()
+
+  useRefetchOnSwitch(connectorConfigsRes.refetch)
 
   // either if whitelisted or already has a connector other than default postgres
   const canAddNewConnectors =
@@ -97,7 +100,10 @@ export default function ConnectorConfigsPage({
       <h2 className="mb-4 text-2xl font-semibold tracking-tight">
         Configured connectors
       </h2>
-      <p className="mb-4 text-sm text-gray-600">Manage and edit your existing integrations here to ensure your workflows run smoothly.</p>
+      <p className="mb-4 text-sm text-gray-600">
+        Manage and edit your existing integrations here to ensure your workflows
+        run smoothly.
+      </p>
       {connectorConfigsRes.data ? (
         <DataTable
           query={connectorConfigsRes}
@@ -186,7 +192,9 @@ export default function ConnectorConfigsPage({
       <h2 className="mb-4 text-2xl font-semibold tracking-tight">
         Available connectors
       </h2>
-      <p className="mb-4 text-sm text-gray-600">Select an integration from the list below to add it to your App.</p>
+      <p className="mb-4 text-sm text-gray-600">
+        Select an integration from the list below to add it to your App.
+      </p>
       {zVerticalKey.options.map((vertical) => {
         const stageByIndex = R.mapToObj.indexed(
           zConnectorStage.options,

--- a/apps/web/app/dashboard/(authenticated)/customers/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/customers/page.tsx
@@ -14,9 +14,12 @@ import {
   DropdownMenuTrigger,
   useToast,
 } from '@openint/ui'
+import useRefetchOnSwitch from '../useRefetchOnSwitch'
 
 export default function CustomersPage() {
   const res = _trpcReact.adminSearchCustomers.useQuery({})
+
+  useRefetchOnSwitch(res.refetch)
 
   // Function to format dates
   function formatDate(dateString: string | null | undefined) {

--- a/apps/web/app/dashboard/(authenticated)/layout.tsx
+++ b/apps/web/app/dashboard/(authenticated)/layout.tsx
@@ -15,6 +15,7 @@ import {NoSSR} from '@/components/NoSSR'
 import {RedirectToNext13} from '@/components/RedirectTo'
 import {VCommandBar} from '@/vcommands/vcommand-components'
 import {Sidebar} from './Sidebar'
+import useRefetchOnSwitch from './useRefetchOnSwitch'
 
 function CustomCreateOrganization() {
   const {createOrganization, setActive} = useOrganizationList()
@@ -71,6 +72,9 @@ export default function AuthedLayout({children}: {children: React.ReactNode}) {
   // auth works for initial request but then subsequently breaks...
   const auth = useAuth()
   const connections = _trpcReact.listConnections.useQuery({})
+
+  useRefetchOnSwitch(connections.refetch)
+
   const hasPgConnection =
     connections.data?.some((c) => c.id.includes('postgres_default')) ?? false
   // const user = useUser()
@@ -140,10 +144,10 @@ export default function AuthedLayout({children}: {children: React.ReactNode}) {
         )}
       </main>
       <Sidebar
-        className="bg-sidebar fixed bottom-0 left-0 top-12 w-[240px] border-r"
+        className="fixed bottom-0 left-0 top-12 w-[240px] border-r bg-sidebar"
         hasPgConnection={hasPgConnection}
       />
-      <header className="bg-navbar fixed inset-x-0 top-0 flex h-12 items-center gap-2 border-b p-4">
+      <header className="fixed inset-x-0 top-0 flex h-12 items-center gap-2 border-b bg-navbar p-4">
         {/* Not working because of bug in clerk js that is unclear that results in hydration issue.. */}
         <NoSSR>
           <div className="mb-[-6px]">

--- a/apps/web/app/dashboard/(authenticated)/pipeline-runs/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/pipeline-runs/page.tsx
@@ -2,11 +2,14 @@
 
 import {DataTable} from '@openint/ui'
 import {trpcReact} from '@/lib-client/trpcReact'
+import useRefetchOnSwitch from '../useRefetchOnSwitch'
 
 export default function SyncRunsPage() {
   const res = trpcReact.listSyncRuns.useQuery()
 
   ;(globalThis as any).listSyncRunsRes = res
+
+  useRefetchOnSwitch(res.refetch)
 
   return (
     <div className="p-6">

--- a/apps/web/app/dashboard/(authenticated)/pipelines/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/pipelines/page.tsx
@@ -3,11 +3,13 @@
 import {DataTable} from '@openint/ui'
 import {trpcReact} from '@/lib-client/trpcReact'
 import {VCommandMenu} from '@/vcommands/vcommand-components'
+import useRefetchOnSwitch from '../useRefetchOnSwitch'
 
 export default function PipelinesPage() {
   const res = trpcReact.listPipelines.useQuery()
-
   ;(globalThis as any).listPipelinesRes = res
+
+  useRefetchOnSwitch(res.refetch)
 
   return (
     <div className="p-6">

--- a/apps/web/app/dashboard/(authenticated)/settings/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/settings/page.tsx
@@ -6,11 +6,13 @@ import {zOrganization} from '@openint/engine-backend/services/AuthProvider'
 import type {TRPCReact} from '@openint/engine-frontend'
 import {_trpcReact, useMutationToast} from '@openint/engine-frontend'
 import {SchemaForm} from '@openint/ui'
+import useRefetchOnSwitch from '../useRefetchOnSwitch'
 
 const trpcReact = _trpcReact as unknown as TRPCReact<AppRouter>
 
 export default function SettingsPage() {
   const res = trpcReact.getCurrentOrganization.useQuery()
+  useRefetchOnSwitch(res.refetch)
 
   const updateOrg = trpcReact.updateCurrentOrganization.useMutation({
     ...useMutationToast({
@@ -26,7 +28,10 @@ export default function SettingsPage() {
   return res && !(res.isLoading || res.isRefetching) ? (
     <div className="p-6">
       <h2 className="mb-4 text-2xl font-semibold tracking-tight">Settings</h2>
-      <p className="mb-4 text-sm text-gray-600">Configure your database, schema, and webhook settings to manage how data is stored, organized, and synced across your integrations.</p>
+      <p className="mb-4 text-sm text-gray-600">
+        Configure your database, schema, and webhook settings to manage how data
+        is stored, organized, and synced across your integrations.
+      </p>
       <SchemaForm
         schema={zOrganization.shape.publicMetadata}
         uiSchema={{

--- a/apps/web/app/dashboard/(authenticated)/useRefetchOnSwitch.ts
+++ b/apps/web/app/dashboard/(authenticated)/useRefetchOnSwitch.ts
@@ -1,0 +1,15 @@
+import {useOrganization} from '@clerk/nextjs'
+import {useEffect} from 'react'
+
+const useRefetchOnSwitch = (refetch: () => void) => {
+  const {organization} = useOrganization()
+
+  useEffect(() => {
+    // Only refetch when organization changes
+    if (organization?.id) {
+      void refetch()
+    }
+  }, [organization?.id])
+}
+
+export default useRefetchOnSwitch


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `useRefetchOnSwitch` hook to refetch data on organization change across multiple pages.
> 
>   - **Behavior**:
>     - Introduces `useRefetchOnSwitch` hook in `useRefetchOnSwitch.ts` to refetch data when the organization changes.
>     - Applies `useRefetchOnSwitch` to `ConnectorConfigPage.tsx`, `CustomersPage.tsx`, `layout.tsx`, `pipeline-runs/page.tsx`, `pipelines/page.tsx`, and `settings/page.tsx` to refetch data on organization switch.
>   - **Misc**:
>     - Minor formatting changes in `ConnectorConfigPage.tsx` and `settings/page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 51114cf20449553a7745105d9d05971a132dd20d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->