### PR TITLE
connector config page width and padding fixes

### DIFF
--- a/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
+++ b/apps/web/app/dashboard/(authenticated)/connector-configs/ConnectorConfigPage.tsx
@@ -96,7 +96,7 @@ export default function ConnectorConfigsPage({
   }
 
   return (
-    <div className="max-w-[60%] p-6">
+    <div className="max-w-[70%] p-6">
       <h2 className="mb-4 text-2xl font-semibold tracking-tight">
         Configured connectors
       </h2>
@@ -227,10 +227,10 @@ export default function ConnectorConfigsPage({
 
         return (
           <div key={vertical}>
-            <h3 className="mb-4 ml-4 text-xl font-semibold tracking-tight">
+            <h3 className="ml-4 text-xl font-semibold tracking-tight">
               {titleCase(vertical)}
             </h3>
-            <div className="flex flex-wrap">
+            <div className="flex flex-wrap mb-4">
               {connectorsWithCTA.map((connector, index) =>
                 index < connectorsWithCTA.length - 1 ? (
                   <ConnectorCard

--- a/apps/web/app/dashboard/(authenticated)/magic-link/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/magic-link/page.tsx
@@ -166,7 +166,7 @@ export default function MagicLinkPage() {
           </div>
           <div className="mt-4">
             <Button type="submit" variant="default">
-              Submit
+              Create Magic Link
             </Button>
           </div>
         </SchemaForm>


### PR DESCRIPTION
<img width="736" alt="image" src="https://github.com/user-attachments/assets/a55e4fd8-3633-44f3-b7bb-3970f8cb9fb1" />

<img width="909" alt="image" src="https://github.com/user-attachments/assets/b38668b7-6848-4bde-99dc-0e0161a22a33" />


fixed width-% to void starting another row just for the "request integration" button

FYI: broken logos probably happened because I've shut the console down. no need to worry about that, just double-checked and it's working fine :) 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI adjustments in `ConnectorConfigPage.tsx` and button renaming in `page.tsx` for improved layout and clarity.
> 
>   - **UI Adjustments**:
>     - In `ConnectorConfigPage.tsx`, increased `max-w` from `60%` to `70%` to prevent the "request integration" button from starting a new row.
>     - Added `mb-4` to the `div` wrapping `connectorsWithCTA` to ensure proper spacing.
>   - **Button Renaming**:
>     - In `page.tsx`, changed button text from `Submit` to `Create Magic Link` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for a4034acc24e2f93d29c531d4eaf4d9913905f79d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->