### PR TITLE
fixed book a demo cta width

### DIFF
--- a/apps/web/app/dashboard/(authenticated)/Sidebar.tsx
+++ b/apps/web/app/dashboard/(authenticated)/Sidebar.tsx
@@ -158,7 +158,7 @@ export function Sidebar({className, hasPgConnection}: SidebarProps) {
           ))}
         </div>
       </ScrollArea>
-      <div className="mt-auto p-4">
+      <div className="mt-auto p-7">
       <Button 
     variant="default" 
     size="sm" 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased padding for the 'Book A Demo' button container in `Sidebar.tsx`.
> 
>   - **UI Change**:
>     - Increased padding from `p-4` to `p-7` for the div containing the 'Book A Demo' button in `Sidebar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for f22673fe91ec66d0ed971d8c7f1b9270562605dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->