### PR TITLE
feat(accounting): adding summarize_by parameter and fixing net income calculation

### DIFF
--- a/kits/sdk/openapi.json
+++ b/kits/sdk/openapi.json
@@ -5635,6 +5635,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "summarize_by",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/kits/sdk/openapi.types.d.ts
+++ b/kits/sdk/openapi.types.d.ts
@@ -4718,6 +4718,7 @@ export interface operations {
         customer?: string
         department?: string
         date_macro?: string
+        summarize_by?: string
       }
     }
     responses: {

--- a/unified/unified-accounting/adapters/qbo-adapter.ts
+++ b/unified/unified-accounting/adapters/qbo-adapter.ts
@@ -84,29 +84,58 @@ const mappers = {
     endPeriod: (e) => e?.data?.Header?.EndPeriod ?? '',
     currency: (e) => e?.data?.Header?.Currency ?? 'USD',
     accountingStandard: (e) =>
-      e?.data?.Header?.Option?.find(
-        (opt: any) => opt.Name === 'AccountingStandard',
-      )?.Value ?? '',
-    totalIncome: (e) =>
-      Number.parseFloat(
-        e?.data?.Rows?.Row[0]?.Summary?.ColData[1]?.value || '0',
-      ),
-    grossProfit: (e) =>
-      Number.parseFloat(
-        e?.data?.Rows?.Row[1]?.Summary?.ColData[1]?.value || '0',
-      ),
-    totalExpenses: (e) =>
-      Number.parseFloat(
-        e?.data?.Rows?.Row[2]?.Summary?.ColData[1]?.value || '0',
-      ),
-    netOperatingIncome: (e) =>
-      Number.parseFloat(
-        e?.data?.Rows?.Row[3]?.Summary?.ColData[1]?.value || '0',
-      ),
-    netIncome: (e) =>
-      Number.parseFloat(
-        e?.data?.Rows?.Row[4]?.Summary?.ColData[1]?.value || '0',
-      ),
+      e?.data?.Header?.Option?.find((opt) => opt.Name === 'AccountingStandard')
+        ?.Value ?? '',
+    totalIncome: (e) => {
+      const columnMap = createColumnMap(e?.data?.Columns?.Column ?? [])
+      const incomeRow = e?.data?.Rows?.Row?.find(
+        (row) => row.group === 'Income',
+      )
+      return Number.parseFloat(
+        incomeRow?.Summary?.ColData?.[columnMap['Total'] as number]?.value ||
+          '0',
+      )
+    },
+    grossProfit: (e) => {
+      const columnMap = createColumnMap(e?.data?.Columns?.Column ?? [])
+      const grossProfitRow = e?.data?.Rows?.Row?.find(
+        (row) => row.group === 'GrossProfit',
+      )
+      return Number.parseFloat(
+        grossProfitRow?.Summary?.ColData?.[columnMap['Total'] as number]
+          ?.value || '0',
+      )
+    },
+    totalExpenses: (e) => {
+      const columnMap = createColumnMap(e?.data?.Columns?.Column ?? [])
+      const expensesRow = e?.data?.Rows?.Row?.find(
+        (row) => row.group === 'Expenses',
+      )
+      return Number.parseFloat(
+        expensesRow?.Summary?.ColData?.[columnMap['Total'] as number]?.value ||
+          '0',
+      )
+    },
+    netOperatingIncome: (e) => {
+      const columnMap = createColumnMap(e?.data?.Columns?.Column ?? [])
+      const netOperatingRow = e?.data?.Rows?.Row?.find(
+        (row) => row.group === 'NetOperatingIncome',
+      )
+      return Number.parseFloat(
+        netOperatingRow?.Summary?.ColData?.[columnMap['Total'] as number]
+          ?.value || '0',
+      )
+    },
+    netIncome: (e) => {
+      const columnMap = createColumnMap(e?.data?.Columns?.Column ?? [])
+      const netIncomeRow = e?.data?.Rows?.Row?.find(
+        (row) => row.group === 'NetIncome',
+      )
+      return Number.parseFloat(
+        netIncomeRow?.Summary?.ColData?.[columnMap['Total'] as number]?.value ||
+          '0',
+      )
+    },
   }),
 
   cashFlow: mapper(zCast<{data: QBO['Report']}>(), unified.cashFlow, {
@@ -298,7 +327,7 @@ export const qboAdapter = {
   getBalanceSheet: async ({instance, input}) => {
     const res = await instance.GET('/reports/BalanceSheet', {
       params: {
-        query: input
+        query: input,
       },
     })
     return mappers.balanceSheet(res)
@@ -306,7 +335,7 @@ export const qboAdapter = {
   getProfitAndLoss: async ({instance, input}) => {
     const res = await instance.GET('/reports/ProfitAndLoss', {
       params: {
-        query: input
+        query: input,
       },
     })
     return mappers.profitAndLoss(res)
@@ -314,7 +343,7 @@ export const qboAdapter = {
   getCashFlow: async ({instance, input}) => {
     const res = await instance.GET('/reports/CashFlow', {
       params: {
-        query: input
+        query: input,
       },
     })
     return mappers.cashFlow(res)
@@ -322,7 +351,7 @@ export const qboAdapter = {
   getTransactionList: async ({instance, input}) => {
     const res = await instance.GET('/reports/TransactionList', {
       params: {
-        query: input
+        query: input,
       },
     })
     return mappers.transactionList(res)
@@ -330,7 +359,7 @@ export const qboAdapter = {
   getCustomerBalance: async ({instance, input}) => {
     const res = await instance.GET('/reports/CustomerBalance', {
       params: {
-        query: input
+        query: input,
       },
     })
     return mappers.customerBalance(res)
@@ -338,7 +367,7 @@ export const qboAdapter = {
   getCustomerIncome: async ({instance, input}) => {
     const res = await instance.GET('/reports/CustomerIncome', {
       params: {
-        query: input
+        query: input,
       },
     })
     return mappers.customerIncome(res)

--- a/unified/unified-accounting/router.ts
+++ b/unified/unified-accounting/router.ts
@@ -93,9 +93,24 @@ export const accountingRouter = trpc.router({
         summary: 'Get Profit and Loss',
       }),
     )
-    .input(baseReportQueryParams.extend({}))
+    .input(
+      baseReportQueryParams.extend({
+        // NOTE: in QBO this is summarize_column_by but we're doing it for consistency with other APIS
+        // we expose that wil work across non column accounting system reports
+        // QBO Supported Values: Total, Month, Week, Days, Quarter, Year, Customers, Vendors, Classes, Departments, Employees, ProductsAndServices
+        summarize_by: z.string().optional(),
+      }),
+    )
     .output(unified.profitAndLoss)
-    .query(async ({input, ctx}) => proxyCallAdapter({input, ctx})),
+    .query(async ({input, ctx}) => {
+      if (input.summarize_by) {
+        console.log('Received summarize_by', input.summarize_by)
+        // @ts-expect-error
+        input.summarize_column_by = input.summarize_by
+        delete input.summarize_by
+      }
+      return proxyCallAdapter({input, ctx})
+    }),
   getCashFlow: procedure
     .meta(
       oapi({


### PR DESCRIPTION
Fixes 
- [[OINT-1024: Unified Accounting P&L returning Total other income not net income](https://linear.app/openint/issue/OINT-1024/unified-accounting-pandl-returning-total-other-income-not-net-income)](https://linear.app/openint/issue/OINT-1024/unified-accounting-pandl-returning-total-other-income-not-net-income)
- [[OINT-1025: Review adding group by (summarize_column_by) to reports/ProfitAndLoss](https://linear.app/openint/issue/OINT-1025/review-adding-group-by-summarize-column-by-to-reportsprofitandloss)](https://linear.app/openint/issue/OINT-1025/review-adding-group-by-summarize-column-by-to-reportsprofitandloss)

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `summarize_by` parameter to accounting API and refactor net income calculation in `qbo-adapter.ts`.
> 
>   - **Behavior**:
>     - Add `summarize_by` parameter to `getBalanceSheet`, `getProfitAndLoss`, `getCashFlow`, `getCustomerBalance`, and `getCustomerIncome` in `router.ts`.
>     - Refactor net income calculation in `qbo-adapter.ts` using `getReportValue()` for `totalIncome`, `grossProfit`, `totalExpenses`, `netOperatingIncome`, and `netIncome`.
>   - **OpenAPI**:
>     - Update `openapi.json` and `openapi.types.d.ts` to include `summarize_by` parameter.
>   - **Misc**:
>     - Add `getReportValue()` utility function in `qbo-adapter.ts` for report value extraction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 20b752488601c2714a2ea7fcc3aea4ee0163f664. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->