### PR TITLE
Running Stably on main PRs

### DIFF
--- a/.github/workflows/stably-workflow.yml
+++ b/.github/workflows/stably-workflow.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Wait for 5 minutes for Vercel Main Branch Deployment
+        run: sleep 300
       - name: Stably Runner Action
         id: stably-runner
         uses: stablyhq/stably-runner-action@v3

--- a/.github/workflows/stably-workflow.yml
+++ b/.github/workflows/stably-workflow.yml
@@ -23,4 +23,4 @@ jobs:
         uses: stablyhq/stably-runner-action@v3
         with:
           api-key: ${{ secrets.STABLY_API_KEY }}
-          test-suite-id: cm5g8i6nc0005l103urkixuxz
+          test-group-id: cm5g8i6nc0005l103urkixuxz

--- a/.github/workflows/stably-workflow.yml
+++ b/.github/workflows/stably-workflow.yml
@@ -1,0 +1,24 @@
+name: Stably Test Runner
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  stably-test-action:
+    name: Stably Test Runner
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Stably Runner Action
+        id: stably-runner
+        uses: stablyhq/stably-runner-action@v3
+        with:
+          api-key: ${{ secrets.STABLY_API_KEY }}
+          test-suite-id: cm5g8i6nc0005l103urkixuxz


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds GitHub Actions workflow to run Stably tests on `main` branch and pull requests with a wait for Vercel deployment.
> 
>   - **Workflow**:
>     - Adds `.github/workflows/stably-workflow.yml` to run Stably tests on `main` branch and pull requests.
>     - Includes a 5-minute wait step for Vercel deployment before running tests.
>     - Utilizes `stablyhq/stably-runner-action@v3` with `api-key` and `test-group-id` inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 02691c7d1ccf5871f0106bb409479a87e46ca557. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->