### PR TITLE
Command shortcuts clean up

### DIFF
--- a/apps/web/vcommands/vcommand-definitions.ts
+++ b/apps/web/vcommands/vcommand-definitions.ts
@@ -16,13 +16,13 @@ const _pipelineCommand = {
 } satisfies CommandDefinitionInput<CommandContext>;
 
 export const pipelineCommands = {
-  'pipeline:create': cmd.identity({
-    ..._pipelineCommand,
-    params: undefined,
-    icon: 'Plus',
-    execute: ({ ctx }) =>
-      ctx.setPipelineSheetState({ pipeline: undefined, open: true }),
-  }),
+  // 'pipeline:create': cmd.identity({
+  //   ..._pipelineCommand,
+  //   params: undefined,
+  //   icon: 'Plus',
+  //   execute: ({ ctx }) =>
+  //     ctx.setPipelineSheetState({ pipeline: undefined, open: true }),
+  // }),
   'pipeline:edit': cmd.identity({
     ..._pipelineCommand,
     icon: 'Pencil',
@@ -148,11 +148,6 @@ const _navCommand = {
 
 // TODO: Dedupe with the links from the navigation sidebar
 export const navCommands = {
-  go_to_home: {
-    ..._navCommand,
-    icon: 'Home',
-    execute: ({ ctx }) => ctx.router.push('/'),
-  },
   go_to_magic_link: {
     ..._navCommand,
     icon: 'Wand',
@@ -170,18 +165,6 @@ export const navCommands = {
     icon: 'Box',
     title: 'Connections',
     execute: ({ ctx }) => ctx.router.push('/dashboard/connections'),
-  },
-  go_to_pipelines: {
-    ..._navCommand,
-    icon: 'ArrowLeftRight',
-    title: 'Pipelines',
-    execute: ({ ctx }) => ctx.router.push('/dashboard/pipelines'),
-  },
-  go_to_pipeline_runs: {
-    ..._navCommand,
-    icon: 'Shuffle',
-    title: 'Pipeline Runs',
-    execute: ({ ctx }) => ctx.router.push('/dashboard/pipeline-runs'),
   },
   go_to_api_key: {
     ..._navCommand,


### PR DESCRIPTION
<img width="571" alt="image" src="https://github.com/user-attachments/assets/6c721a52-3e23-4dbc-b29a-659dd0fc6843" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Commented out unused command shortcuts in `vcommand-definitions.ts` for cleanup purposes.
> 
>   - **Command Cleanup**:
>     - Commented out `pipeline:create` command in `pipelineCommands`.
>     - Commented out `go_to_home`, `go_to_pipelines`, and `go_to_pipeline_runs` commands in `navCommands`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 70b9454ab7bc0386e03fc923cd373acaaa2db462. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->