### PR TITLE
Integrations filtering moved to the backend and handle customer filters from url

### DIFF
--- a/apps/web/__tests__/end-to-end.spec.ts
+++ b/apps/web/__tests__/end-to-end.spec.ts
@@ -262,9 +262,8 @@ test('list connector config info', async () => {
 test('list configured integrations', async () => {
   const res = await sdk.GET('/configured_integrations')
 
-  expect(res.data.items).toHaveLength(2)
+  expect(res.data.items).toHaveLength(1)
   expect(res.data.items[0]?.connector_name).toEqual('plaid')
-  expect(res.data.items[1]?.connector_name).toEqual('greenhouse')
 
   // Check basic properties
   expect(res.data.items[0]).toHaveProperty('connector_config_id')

--- a/kits/sdk/openapi.types.d.ts
+++ b/kits/sdk/openapi.types.d.ts
@@ -2460,6 +2460,8 @@ export interface operations {
         page_size?: number
         search_text?: string
         connector_config_ids?: string[]
+        enabled_integration_ids?: string[]
+        customer_integration_filters?: string[]
       }
     }
     responses: {

--- a/kits/sdk/openapi.types.d.ts
+++ b/kits/sdk/openapi.types.d.ts
@@ -2460,7 +2460,6 @@ export interface operations {
         page_size?: number
         search_text?: string
         connector_config_ids?: string[]
-        enabled_integration_ids?: string[]
         customer_integration_filters?: string[]
       }
     }

--- a/packages/engine-backend/router/connectorRouter.ts
+++ b/packages/engine-backend/router/connectorRouter.ts
@@ -195,8 +195,7 @@ export const connectorRouter = trpc.mergeRouters(
           search_text: z.string().optional(),
           connector_config_ids: z.array(z.string()).optional(),
           enabled_integration_ids: z.array(z.string()).optional(),
-          // Support int_google_drive, google_drive, jira,etc.
-          customer_integration_filters: z.array(z.string()).optional(),
+          customer_integration_filters: z.array(z.string()).optional(), // Support int_google_drive, google_drive, jira,etc.
         }),
       )
       .output(
@@ -240,6 +239,10 @@ export const connectorRouter = trpc.mergeRouters(
           .createCaller(ctx)
           .listConnection()
 
+        const hasCustomerFilters =
+          input.customer_integration_filters &&
+          input.customer_integration_filters.length > 0
+
         // TODO: Implement filtering in each of the connectors instead?
 
         // integration should have connector name...
@@ -251,6 +254,10 @@ export const connectorRouter = trpc.mergeRouters(
               (int) =>
                 !connections.some(
                   (conn) =>
+                    (hasCustomerFilters &&
+                      !input.customer_integration_filters?.some((filter) =>
+                        int.id.includes(filter),
+                      )) ||
                     (conn.integrationId === null &&
                       conn.connectorConfigId === int.connector_config_id) ||
                     input.enabled_integration_ids?.includes(int.id),

--- a/packages/engine-backend/router/connectorRouter.ts
+++ b/packages/engine-backend/router/connectorRouter.ts
@@ -194,7 +194,6 @@ export const connectorRouter = trpc.mergeRouters(
         zPaginationParams.extend({
           search_text: z.string().optional(),
           connector_config_ids: z.array(z.string()).optional(),
-          enabled_integration_ids: z.array(z.string()).optional(),
           customer_integration_filters: z.array(z.string()).optional(), // Support int_google_drive, google_drive, jira,etc.
         }),
       )
@@ -260,7 +259,7 @@ export const connectorRouter = trpc.mergeRouters(
                       )) ||
                     (conn.integrationId === null &&
                       conn.connectorConfigId === int.connector_config_id) ||
-                    input.enabled_integration_ids?.includes(int.id),
+                    conn.integrationId === int.id,
                 ),
             ),
           next_cursor: null, // Implement me...

--- a/packages/engine-backend/router/connectorRouter.ts
+++ b/packages/engine-backend/router/connectorRouter.ts
@@ -5,6 +5,7 @@ import {getProtectedContext, TRPCError} from '@openint/trpc'
 import {R, z} from '@openint/util'
 import {zBaseRecord, zPaginatedResult, zPaginationParams} from '@openint/vdk'
 import {publicProcedure, trpc} from './_base'
+import {connectionRouter} from './connectionRouter'
 
 const tags = ['Connectors']
 
@@ -193,6 +194,9 @@ export const connectorRouter = trpc.mergeRouters(
         zPaginationParams.extend({
           search_text: z.string().optional(),
           connector_config_ids: z.array(z.string()).optional(),
+          enabled_integration_ids: z.array(z.string()).optional(),
+          // Support int_google_drive, google_drive, jira,etc.
+          customer_integration_filters: z.array(z.string()).optional(),
         }),
       )
       .output(
@@ -232,13 +236,26 @@ export const connectorRouter = trpc.mergeRouters(
                 }))
             }),
         )
+        const connections = await connectionRouter
+          .createCaller(ctx)
+          .listConnection()
 
         // TODO: Implement filtering in each of the connectors instead?
 
         // integration should have connector name...
         return {
           has_next_page: integrations.some((int) => int.has_next_page),
-          items: integrations.flatMap((int) => int.items),
+          items: integrations
+            .flatMap((int) => int.items)
+            .filter(
+              (int) =>
+                !connections.some(
+                  (conn) =>
+                    (conn.integrationId === null &&
+                      conn.connectorConfigId === int.connector_config_id) ||
+                    input.enabled_integration_ids?.includes(int.id),
+                ),
+            ),
           next_cursor: null, // Implement me...
         }
       }),

--- a/packages/engine-frontend/components/AddConnectionTabContent.tsx
+++ b/packages/engine-frontend/components/AddConnectionTabContent.tsx
@@ -5,12 +5,10 @@ interface AddConnectionTabContentProps {
   connectorConfigFilters: ConnectorConfigFilters
   refetch: () => void
   onSuccessCallback?: () => void
-  enabledIntegrationIds?: string[]
 }
 
 export function AddConnectionTabContent({
   connectorConfigFilters,
-  enabledIntegrationIds = [],
   refetch,
   onSuccessCallback,
 }: AddConnectionTabContentProps) {
@@ -23,7 +21,6 @@ export function AddConnectionTabContent({
       </div>
       <ConnectIntegrations
         connectorConfigFilters={connectorConfigFilters}
-        enabledIntegrationIds={enabledIntegrationIds}
         onEvent={(event) => {
           if (event.type === 'close') {
             refetch()

--- a/packages/engine-frontend/components/AddConnectionTabContent.tsx
+++ b/packages/engine-frontend/components/AddConnectionTabContent.tsx
@@ -5,13 +5,11 @@ interface AddConnectionTabContentProps {
   connectorConfigFilters: ConnectorConfigFilters
   refetch: () => void
   onSuccessCallback?: () => void
-  connectorNames?: string[]
   enabledIntegrationIds?: string[]
 }
 
 export function AddConnectionTabContent({
   connectorConfigFilters,
-  connectorNames = [],
   enabledIntegrationIds = [],
   refetch,
   onSuccessCallback,
@@ -25,7 +23,6 @@ export function AddConnectionTabContent({
       </div>
       <ConnectIntegrations
         connectorConfigFilters={connectorConfigFilters}
-        connectorNames={connectorNames}
         enabledIntegrationIds={enabledIntegrationIds}
         onEvent={(event) => {
           if (event.type === 'close') {

--- a/packages/engine-frontend/components/ConnectIntegrations.tsx
+++ b/packages/engine-frontend/components/ConnectIntegrations.tsx
@@ -6,11 +6,9 @@ import {IntegrationSearch} from './IntegrationSearch'
 
 export function ConnectIntegrations({
   connectorConfigFilters,
-  enabledIntegrationIds = [],
   onEvent,
 }: {
   connectorConfigFilters: ConnectorConfigFilters
-  enabledIntegrationIds?: string[]
   onEvent: (event: any) => void
 }) {
   return (
@@ -18,7 +16,6 @@ export function ConnectIntegrations({
       {({ccfgs}) => (
         <IntegrationSearch
           connectorConfigs={ccfgs}
-          enabledIntegrationIds={enabledIntegrationIds}
           onEvent={(e) => {
             if (onEvent) onEvent(e)
           }}

--- a/packages/engine-frontend/components/ConnectIntegrations.tsx
+++ b/packages/engine-frontend/components/ConnectIntegrations.tsx
@@ -10,24 +10,20 @@ export function ConnectIntegrations({
   onEvent,
 }: {
   connectorConfigFilters: ConnectorConfigFilters
-  connectorNames?: string[]
   enabledIntegrationIds?: string[]
   onEvent: (event: any) => void
 }) {
   return (
     <WithConnectConfig {...connectorConfigFilters}>
-      {({ccfgs}) => {
-
-        return (
-          <IntegrationSearch
-            connectorConfigs={ccfgs}
-            enabledIntegrationIds={enabledIntegrationIds}
-            onEvent={(e) => {
-              if (onEvent) onEvent(e)
-            }}
-          />
-        )
-      }}
+      {({ccfgs}) => (
+        <IntegrationSearch
+          connectorConfigs={ccfgs}
+          enabledIntegrationIds={enabledIntegrationIds}
+          onEvent={(e) => {
+            if (onEvent) onEvent(e)
+          }}
+        />
+      )}
     </WithConnectConfig>
   )
 }

--- a/packages/engine-frontend/components/ConnectionPortal.tsx
+++ b/packages/engine-frontend/components/ConnectionPortal.tsx
@@ -145,7 +145,6 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
             ) : (
               <AddConnectionTabContent
                 connectorConfigFilters={{}}
-                connectorNames={connections.map((c) => c.connectorName)}
                 enabledIntegrationIds={enabledIntegrationIds}
                 refetch={listConnectionsRes.refetch}
                 onSuccessCallback={() => {

--- a/packages/engine-frontend/components/ConnectionPortal.tsx
+++ b/packages/engine-frontend/components/ConnectionPortal.tsx
@@ -113,13 +113,6 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
           listConnectionsRes.isFetching ||
           listConnectionsRes.isRefetching
 
-        const enabledIntegrationIds: string[] =
-          listConnectionsRes.data
-            ?.filter((c): c is typeof c & {integration: {id: string}} =>
-              Boolean(c?.integration?.id),
-            )
-            .map((c) => c.integration.id) ?? []
-
         const tabConfig = [
           {
             key: 'connections',
@@ -145,7 +138,6 @@ export function ConnectionPortal({className}: ConnectionPortalProps) {
             ) : (
               <AddConnectionTabContent
                 connectorConfigFilters={{}}
-                enabledIntegrationIds={enabledIntegrationIds}
                 refetch={listConnectionsRes.refetch}
                 onSuccessCallback={() => {
                   navigateToTab('connections')

--- a/packages/engine-frontend/components/IntegrationSearch.tsx
+++ b/packages/engine-frontend/components/IntegrationSearch.tsx
@@ -17,12 +17,10 @@ export function IntegrationSearch({
   className,
   connectorConfigs,
   onEvent,
-  enabledIntegrationIds = [],
 }: {
   className?: string
   /** TODO: Make this optional so it is easier to use it as a standalone component */
   connectorConfigs: ConnectorConfig[]
-  enabledIntegrationIds?: string[]
   onEvent?: (event: {
     integration: {
       connectorConfigId: string

--- a/packages/engine-frontend/components/IntegrationSearch.tsx
+++ b/packages/engine-frontend/components/IntegrationSearch.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {Loader, Search} from 'lucide-react'
+import {useSearchParams} from 'next/navigation'
 import {useCallback, useEffect, useState} from 'react'
 import type {Id} from '@openint/cdk'
 import {Button, cn, Input, parseCategory, Separator} from '@openint/ui'
@@ -35,6 +36,9 @@ export function IntegrationSearch({
   // Main state after applying filters.
   const [categoryFilter, setCategoryFilter] = useState<string[]>([])
 
+  const searchParams = useSearchParams()
+  const integrationFilters = searchParams.get('integrationFilters')
+
   const debouncedSetSearch = useCallback((value: string) => {
     const timeoutId = setTimeout(() => {
       setDebouncedSearchText(value)
@@ -52,6 +56,7 @@ export function IntegrationSearch({
     connector_config_ids: connectorConfigs.map((ccfg) => ccfg.id),
     search_text: debouncedSearchText,
     enabled_integration_ids: enabledIntegrationIds,
+    customer_integration_filters: integrationFilters?.split(',') ?? [],
   })
   const ints = listIntegrationsRes.data?.items.map((int) => ({
     ...int,

--- a/packages/engine-frontend/components/IntegrationSearch.tsx
+++ b/packages/engine-frontend/components/IntegrationSearch.tsx
@@ -51,15 +51,12 @@ export function IntegrationSearch({
   const listIntegrationsRes = _trpcReact.listConfiguredIntegrations.useQuery({
     connector_config_ids: connectorConfigs.map((ccfg) => ccfg.id),
     search_text: debouncedSearchText,
+    enabled_integration_ids: enabledIntegrationIds,
   })
-  const ints = listIntegrationsRes.data?.items
-    .map((int) => ({
-      ...int,
-      ccfg: connectorConfigs.find(
-        (ccfg) => ccfg.id === int.connector_config_id,
-      )!,
-    }))
-    .filter((int) => !enabledIntegrationIds.includes(int.id))
+  const ints = listIntegrationsRes.data?.items.map((int) => ({
+    ...int,
+    ccfg: connectorConfigs.find((ccfg) => ccfg.id === int.connector_config_id)!,
+  }))
 
   const categories = Array.from(
     new Set(connectorConfigs.flatMap((ccfg) => ccfg.verticals)),

--- a/packages/engine-frontend/components/IntegrationSearch.tsx
+++ b/packages/engine-frontend/components/IntegrationSearch.tsx
@@ -55,7 +55,6 @@ export function IntegrationSearch({
   const listIntegrationsRes = _trpcReact.listConfiguredIntegrations.useQuery({
     connector_config_ids: connectorConfigs.map((ccfg) => ccfg.id),
     search_text: debouncedSearchText,
-    enabled_integration_ids: enabledIntegrationIds,
     customer_integration_filters: integrationFilters?.split(',') ?? [],
   })
   const ints = listIntegrationsRes.data?.items.map((int) => ({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Moved integration filtering to backend and added URL-based customer filters, updating both backend logic and frontend components accordingly.
> 
>   - **Backend Changes**:
>     - `connectorRouter.ts`: Updated `listConfiguredIntegrations` to filter integrations based on `customer_integration_filters` and `connector_config_ids`.
>     - Added `customer_integration_filters` to `operations` in `openapi.types.d.ts`.
>   - **Frontend Changes**:
>     - Removed `connectorNames` and `enabledIntegrationIds` props from `AddConnectionTabContent.tsx`, `ConnectIntegrations.tsx`, and `ConnectionPortal.tsx`.
>     - `IntegrationSearch.tsx`: Uses `customer_integration_filters` from URL search params for backend query.
>   - **Tests**:
>     - Updated `end-to-end.spec.ts` to expect only one configured integration instead of two.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for c8ad609a24fa54c098ee7569b2601fb64db23916. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->