### PR TITLE
hover colors fix

### DIFF
--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -13,7 +13,7 @@
     --foreground: hsl(250, 12%, 20%);
 
     --muted: hsl(0, 0%, 95%);
-    --muted-foreground: hsl(235, 16%, 29%);
+    --muted-foreground: hsl(0, 0%, 27%);
 
     --popover: hsl(0, 0%, 100%);
     --popover-foreground: hsl(250, 12%, 20%);
@@ -76,17 +76,17 @@
     --background: hsl(0, 0, 11%);
     --foreground: hsl(0, 0%, 96.5%);
 
-    --muted: hsl(215, 50%, 61%);
+    --muted: hsla(0, 0%, 100%, 0.097);
     --muted-foreground: hsl(0, 0%, 60%);
 
-    --accent: hsl(220, 21%, 39%);
-    --accent-foreground: hsl(220, 35%, 92%);
+    --accent: hsla(0, 0%, 100%, 0.097);
+    --accent-foreground: hsla(0, 0%, 92%, 0.635);
 
     --popover: hsl(0, 0%, 14%);
     --popover-foreground: hsl(0, 0%, 96.5%);
 
     --border: hsl(0, 0%, 20%);
-    --input: hsl(220, 21%, 39%);
+    --input: hsla(0, 0%, 100%, 0.097);
 
     --card: hsl(0, 0%, 14%);
     --card-border: hsl(0, 0%, 20%);
@@ -101,7 +101,7 @@
     --destructive: hsl(7, 68%, 53%);
     --destructive-foreground: hsl(220, 35%, 92%);
 
-    --ring: hsl(220, 21%, 39%);
+    --ring: hsla(0, 0%, 100%, 0.097);
 
     --button: hsl(255, 90%, 66%);
     --button-light: hsl(255, 90%, 96%);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix hover colors by adjusting CSS variables in `global.css` for light and dark themes.
> 
>   - **CSS Variables**:
>     - Adjust `--muted-foreground` from `hsl(235, 16%, 29%)` to `hsl(0, 0%, 27%)`.
>     - Change `--muted`, `--accent`, `--input`, and `--ring` to `hsla(0, 0%, 100%, 0.097)` in dark theme.
>     - Update `--accent-foreground` to `hsla(0, 0%, 92%, 0.635)` in dark theme.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 1aa310aba8b1a3ec9e74b2b0ccef00ec603b6563. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->