### PR TITLE
Add spinner to integration cards when preconnect is triggered

### DIFF
--- a/packages/engine-frontend/components/IntegrationSearch.tsx
+++ b/packages/engine-frontend/components/IntegrationSearch.tsx
@@ -198,7 +198,7 @@ export function IntegrationSearch({
                               },
                             })
                           }}>
-                          {({openConnect}) => (
+                          {({openConnect, loading}) => (
                             <IntegrationCard
                               onClick={openConnect}
                               logo={
@@ -206,6 +206,7 @@ export function IntegrationSearch({
                               }
                               name={int.name}
                               hasDeeplink={hasDeeplink}
+                              isLoading={loading}
                             />
                           )}
                         </WithConnectorConnect>

--- a/packages/engine-frontend/hocs/WithConnectorConnect.tsx
+++ b/packages/engine-frontend/hocs/WithConnectorConnect.tsx
@@ -67,6 +67,8 @@ export const WithConnectorConnect = ({
   // TODO: Restore connectFnMap so that we respect the rules of hooks to always render all hooks
   // and not skip rendering or conditionally rendering hooks
 
+  const [isPreconnecting, setIsPreconnecting] = React.useState(false)
+
   const useConnectHook = clientConnectors[ccfg.connector.name]?.useConnectHook
   const nangoProvider = ccfg.connector.nangoProvider
 
@@ -179,6 +181,7 @@ export const WithConnectorConnect = ({
           })
         }
         setOpen(false)
+        setIsPreconnecting(false)
         onEvent?.({type: 'success'})
       },
       onError: (err) => {
@@ -210,7 +213,13 @@ export const WithConnectorConnect = ({
     // non modal dialog do not add pointer events none to the body
     // which workaround issue with multiple portals (dropdown, dialog) conflicting
     // as well as other modals introduced by things like Plaid
-    <Dialog open={open} onOpenChange={setOpen} modal={false}>
+    <Dialog
+      open={open}
+      onOpenChange={(newValue) => {
+        setOpen(newValue)
+        setIsPreconnecting(newValue)
+      }}
+      modal={false}>
       {children({
         // Children is responsible for rendering dialog triggers as needed
         openConnect: () => {
@@ -222,11 +231,13 @@ export const WithConnectorConnect = ({
             // and a hard api to work with. We sacrifice some accessiblity by
             // using explicit callback rather than DialogTrigger component
             setOpen(true)
+            setIsPreconnecting(true)
+
             return
           }
           connect.mutate(undefined)
         },
-        loading: connect.isLoading,
+        loading: connect.isLoading || isPreconnecting,
         variant: connection?.status === 'disconnected' ? 'default' : 'ghost',
         label: connection ? 'Reconnect' : 'Connect',
       })}

--- a/packages/ui/domain-components/IntegrationCard.tsx
+++ b/packages/ui/domain-components/IntegrationCard.tsx
@@ -1,4 +1,4 @@
-import {Plus} from 'lucide-react'
+import {Loader, Plus} from 'lucide-react'
 import {useEffect, useRef, useState} from 'react'
 import {Card, CardContent} from '../shadcn'
 import {
@@ -13,11 +13,13 @@ export function IntegrationCard({
   name,
   onClick,
   hasDeeplink,
+  isLoading = false,
 }: {
   logo: string
   name: string
   onClick: () => void
   hasDeeplink: boolean
+  isLoading?: boolean
 }) {
   const [isHovered, setIsHovered] = useState(false)
   const hasAutoConnected = useRef(false)
@@ -40,7 +42,9 @@ export function IntegrationCard({
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}>
             <CardContent
-              className="flex h-full flex-col items-center justify-center py-4"
+              className={`flex h-full flex-col items-center justify-center py-4 ${
+                isLoading ? 'opacity-40' : ''
+              }`}
               onClick={onClick}>
               {isHovered ? (
                 <div className="flex h-full flex-col items-center justify-center">
@@ -66,6 +70,11 @@ export function IntegrationCard({
                 </div>
               )}
             </CardContent>
+            {isLoading && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center">
+                <Loader className="size-7 animate-spin text-button" />
+              </div>
+            )}
           </Card>
         </TooltipTrigger>
         <TooltipContent>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add loading spinner to `IntegrationCard` during preconnect in `IntegrationSearch` and `WithConnectorConnect`.
> 
>   - **Behavior**:
>     - Adds a loading spinner to `IntegrationCard` when preconnect is triggered.
>     - Uses `isLoading` prop in `IntegrationCard` to control spinner visibility.
>   - **Components**:
>     - `IntegrationSearch`: Passes `loading` state to `IntegrationCard`.
>     - `WithConnectorConnect`: Manages `isPreconnecting` state and passes combined loading state to children.
>     - `IntegrationCard`: Displays spinner overlay when `isLoading` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 5196556244bbba5873085b4da86ce8efef7a8ded. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->