### PR TITLE
Explicitly trigger Stably workflow action

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -147,3 +147,7 @@ jobs:
           git fetch origin main
           git checkout main
           git push origin main:production -f
+
+      - name: Trigger Stably Workflow
+        run: |
+          gh workflow run stably-workflow.yml

--- a/.github/workflows/stably-workflow.yml
+++ b/.github/workflows/stably-workflow.yml
@@ -1,6 +1,7 @@
 name: Stably Test Runner
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - production


### PR DESCRIPTION
This should resolve an issue where GitHub doesn't let pushes from actions trigger subsequent actions. In our case, that's trigger the Stably workflow action after the release action runs and pushes to the `production` branch.

An alternative to this change would be to follow official guidance here (https://github.com/orgs/community/discussions/25702) for setting a PAT for doing the push to `production`, thus bypassing GitHub's default behavior. I, however, do not have those permissions.

Please feel to test and use this (or not)!