### PR TITLE
Connection validation and making expires_at optional

### DIFF
--- a/kits/cdk/internal/oauthConnector.ts
+++ b/kits/cdk/internal/oauthConnector.ts
@@ -33,7 +33,7 @@ const zOauthCredentials = z.object({
   api_key: z.string().nullish(),
   access_token: z.string().optional(),
   refresh_token: z.string().optional(),
-    // sometimes this is missing from the response
+  // sometimes this is missing from the response
   expires_at: z.string().datetime().optional(),
   raw: z.object({
     access_token: z.string(),

--- a/kits/cdk/internal/oauthConnector.ts
+++ b/kits/cdk/internal/oauthConnector.ts
@@ -37,8 +37,8 @@ const zOauthCredentials = z.object({
   expires_at: z.string().datetime().optional(),
   raw: z.object({
     access_token: z.string(),
-    expires_in: z.number(),
     // sometimes this is missing from the response
+    expires_in: z.number().optional(),
     expires_at: z.string().datetime().optional(),
     /** Refresh token (Only returned if the REFRESH_TOKEN boolean parameter is set to true and the refresh token is available) */
     refresh_token: z.string().nullish(),

--- a/packages/api/proxyHandler.ts
+++ b/packages/api/proxyHandler.ts
@@ -14,8 +14,7 @@ export const proxyHandler = async (req: Request) => {
   const protectedContext = getProtectedContext(ctx)
   const remoteContext = await getRemoteContext(protectedContext)
 
-  const credentialsExpired = remoteContext.remote.settings.oauth?.credentials
-    .expires_at
+  const credentialsExpired = remoteContext.remote.settings.oauth?.credentials?.expires_at
     ? new Date(remoteContext.remote.settings.oauth.credentials.expires_at) <
       new Date()
     : false

--- a/packages/engine-backend/router/connectionRouter.ts
+++ b/packages/engine-backend/router/connectionRouter.ts
@@ -262,9 +262,9 @@ export const connectionRouter = trpc.router({
     .output(z.object({}))
     .mutation(async ({input: {id: connId, ...opts}, ctx}) => {
       if (ctx.viewer.role === 'customer') {
-        await ctx.services.getConnectionOrFail(connId)
+        await ctx.services.getConnectionOrFail(connId, true)
       }
-      const conn = await ctx.asOrgIfNeeded.getConnectionExpandedOrFail(connId)
+      const conn = await ctx.asOrgIfNeeded.getConnectionExpandedOrFail(connId, true)
       const {settings, connectorConfig: ccfg} = conn
       if (!opts?.skipRevoke) {
         await ccfg.connector.revokeConnection?.(

--- a/packages/engine-backend/services/dbService.ts
+++ b/packages/engine-backend/services/dbService.ts
@@ -142,7 +142,7 @@ export function makeDBService({
     return getOrFail(tableName, id)
   }
 
-  const getConnectorConfigInfoOrFail = (id: Id['ccfg']) =>
+  const getConnectorConfigInfoOrFail = (id: Id['ccfg'], skipValidation = false) =>
     metaService.listConnectorConfigInfos({id}).then((ints) => {
       if (!ints[0]) {
         throw new TRPCError({
@@ -150,10 +150,10 @@ export function makeDBService({
           message: `ccfg info not found: ${id}`,
         })
       }
-      return ints[0]
+      return skipValidation ? ints[0] : zRaw.connector_config.parse(ints[0])
     })
 
-  const getConnectorConfigOrFail = (id: Id['ccfg']) =>
+  const getConnectorConfigOrFail = (id: Id['ccfg'], skipValidation = false) =>
     metaService.tables.connector_config.get(id).then((_ccfg) => {
       if (!_ccfg) {
         throw new TRPCError({
@@ -163,11 +163,13 @@ export function makeDBService({
       }
       const int = zRaw.connector_config.parse(_ccfg)
       const connector = getConnectorOrFail(int.id)
-      const config: {} = connector.schemas.connectorConfig?.parse(int.config)
+      const config: {} = skipValidation
+        ? int.config
+        : connector.schemas.connectorConfig?.parse(int.config)
       return {...int, connector, config}
     })
 
-  const getIntegrationOrFail = (id: Id['int']) =>
+  const getIntegrationOrFail = (id: Id['int'], skipValidation = false) =>
     metaService.tables.integration.get(id).then(async (ins) => {
       if (!ins) {
         throw new TRPCError({
@@ -182,7 +184,7 @@ export function makeDBService({
         ins.standard = provider?.standardMappers?.integration?.(ins.external)
         await metaLinks.patch('integration', ins.id, {standard: ins.standard})
       }
-      return zRaw.integration.parse(ins)
+      return skipValidation ? ins : zRaw.integration.parse(ins)
     })
   const getConnectionOrFail = (id: Id['conn'], skipValidation = false) =>
     metaService.tables.connection.get(id).then((conn) => {
@@ -197,7 +199,7 @@ export function makeDBService({
       }
       return conn
     })
-  const getPipelineOrFail = (id: Id['pipe']) =>
+  const getPipelineOrFail = (id: Id['pipe'], skipValidation = false) =>
     metaService.tables.pipeline.get(id).then((pipe) => {
       if (!pipe) {
         throw new TRPCError({
@@ -205,13 +207,14 @@ export function makeDBService({
           message: `pipe not found: ${id}`,
         })
       }
-      return zRaw.pipeline.parse(pipe)
+      return skipValidation ? pipe : zRaw.pipeline.parse(pipe)
     })
 
   const getConnectionExpandedOrFail = (id: Id['conn'], skipValidation = false) =>
     getConnectionOrFail(id).then(async (conn) => {
       const connectorConfig = await getConnectorConfigOrFail(
         conn.connectorConfigId,
+        skipValidation,
       )
       const settings: {} = skipValidation
         ? conn.settings
@@ -219,16 +222,16 @@ export function makeDBService({
             conn.settings,
           )
       const integration = conn.integrationId
-        ? await getIntegrationOrFail(conn.integrationId)
+        ? await getIntegrationOrFail(conn.integrationId, skipValidation)
         : undefined
       return {...conn, connectorConfig, settings, integration}
     })
 
-  const getPipelineExpandedOrFail = (id: Id['pipe']) =>
+  const getPipelineExpandedOrFail = (id: Id['pipe'], skipValidation = false) =>
     getPipelineOrFail(id).then(async (pipe) => {
       const [source, destination] = await Promise.all([
-        getConnectionExpandedOrFail(pipe.sourceId!),
-        getConnectionExpandedOrFail(pipe.destinationId!),
+        getConnectionExpandedOrFail(pipe.sourceId!, skipValidation),
+        getConnectionExpandedOrFail(pipe.destinationId!, skipValidation),
       ])
       // if (
       //   pipe.sourceState != null &&
@@ -248,13 +251,17 @@ export function makeDBService({
       //     message: `destinationState is not supported for ${destination.connectorConfig.connector.name}`,
       //   })
       // }
-      const sourceState: {} = (
-        source.connectorConfig.connector.schemas.sourceState ?? z.unknown()
-      ).parse(pipe.sourceState)
-      const destinationState: {} = (
-        destination.connectorConfig.connector.schemas.destinationState ??
-        z.unknown()
-      ).parse(pipe.destinationState)
+      const sourceState: {} = skipValidation
+        ? pipe.sourceState
+        : (
+            source.connectorConfig.connector.schemas.sourceState ?? z.unknown()
+          ).parse(pipe.sourceState)
+      const destinationState: {} = skipValidation
+        ? pipe.destinationState
+        : (
+            destination.connectorConfig.connector.schemas.destinationState ??
+            z.unknown()
+          ).parse(pipe.destinationState)
       // const links = R.pipe(
       //   rest.linkOptions ?? pipeline?.linkOptions ?? [],
       //   R.map((l) =>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances connection validation by introducing optional `expires_at` in OAuth credentials and adding a `skipValidation` parameter for flexible schema validation.
> 
>   - **Behavior**:
>     - Introduces `zOauthCredentials` schema in `oauthConnector.ts` to handle optional `expires_at` in OAuth credentials.
>     - Updates `proxyHandler.ts` to check for optional `expires_at` in credentials.
>     - Modifies `connectionRouter.ts` to pass `true` for `skipValidation` in `getConnectionOrFail()` and `getConnectionExpandedOrFail()`.
>   - **Validation**:
>     - Adds `skipValidation` parameter to `getConnectorConfigOrFail()`, `getIntegrationOrFail()`, `getConnectionOrFail()`, `getPipelineOrFail()`, `getConnectionExpandedOrFail()`, and `getPipelineExpandedOrFail()` in `dbService.ts`.
>     - Uses `skipValidation` to bypass schema validation when necessary.
>   - **Misc**:
>     - Refactors `oauthConnector.ts` to use `zOauthCredentials` in `oauthBaseSchema`.
>     - Fixes optional chaining in `proxyHandler.ts` for `credentialsExpired` check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for d069ddc7c3b3ccc644533c0600ca39feddd7d32e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->