### PR TITLE
Add token to step

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -149,5 +149,7 @@ jobs:
           git push origin main:production -f
 
       - name: Trigger Stably Workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run stably-workflow.yml


### PR DESCRIPTION
Should fix issue https://github.com/openintegrations/openint/actions/runs/13019004359/job/36315096205
![image](https://github.com/user-attachments/assets/cd87b3d9-c3c4-47e2-810a-5f8e3800ed9a)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `GH_TOKEN` to `Trigger Stably Workflow` step in `release-workflow.yml` for authentication.
> 
>   - **Workflow Changes**:
>     - Add `GH_TOKEN` environment variable to `Trigger Stably Workflow` step in `release-workflow.yml` to ensure authentication when running `stably-workflow.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 66ad80d2984619b5e74eb5ccf39e05f749a12526. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->