### PR TITLE
Move check from postConnect to checkConnection

### DIFF
--- a/connectors/connector-aircall/server.ts
+++ b/connectors/connector-aircall/server.ts
@@ -21,10 +21,10 @@ export const aircallServer = {
     })
     return aircall
   },
-  postConnect: async (connectOutput, _, context) => {
+  checkConnection: async ({settings}) => {
     // Encoding credentials:
-    const apiId = context.connection?.settings.apiId
-    const apiToken = context.connection?.settings.apiToken
+    const apiId = settings.apiId
+    const apiToken = settings.apiToken
     const encodedCredentials = Buffer.from(`${apiId}:${apiToken}`).toString(
       'base64',
     )
@@ -53,8 +53,7 @@ export const aircallServer = {
     }
 
     return {
-      connectionExternalId: connectOutput.connectionId,
-      providerConfigKey: connectOutput.providerConfigKey,
+      connectionExternalId: settings.apiId,
     }
   },
 } satisfies ConnectorServer<

--- a/connectors/connector-aircall/server.ts
+++ b/connectors/connector-aircall/server.ts
@@ -44,12 +44,14 @@ export const aircallServer = {
         console.error(
           `HTTP error! status: ${response.status} - ${response.statusText}`,
         )
+        throw new Error('Invalid Aircall credentials')
       }
 
       const body = await response.text()
       console.log('Response from Aircall Ping:', body)
     } catch (error) {
       console.error('Error during fetch:', error)
+      throw error
     }
 
     return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move connection check from `postConnect` to `checkConnection` in `server.ts`, accessing credentials from `settings` and modifying return object.
> 
>   - **Function Changes**:
>     - Move connection check logic from `postConnect` to `checkConnection` in `server.ts`.
>     - Access `apiId` and `apiToken` from `settings` instead of `context.connection?.settings`.
>     - Return `connectionExternalId` from `settings.apiId`.
>   - **Error Handling**:
>     - Throw error directly on failed fetch in `checkConnection`.
>     - Log errors and responses consistently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 24f3a4e644f2e16666adaec5f3cc772214cbebd4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->