### PR TITLE
feat(stably): navigate to magic link url on main

### DIFF
--- a/apps/app-config/constants.ts
+++ b/apps/app-config/constants.ts
@@ -46,3 +46,7 @@ export const __DEBUG__ =
       !!process.env['DEBUG']
 
 export const isProd = getServerUrl(null).includes('app.openint.dev')
+
+export const isMainPreview = getServerUrl(null).includes(
+  'openint-git-main-openint-dev.vercel.app',
+)

--- a/apps/web/app/dashboard/(authenticated)/connect/page.tsx
+++ b/apps/web/app/dashboard/(authenticated)/connect/page.tsx
@@ -2,6 +2,7 @@
 
 import {ChevronDown} from 'lucide-react'
 import {useState} from 'react'
+import {isMainPreview} from '@openint/app-config/constants'
 import {customerRouterSchema} from '@openint/engine-backend/router/customerRouter'
 import {_trpcReact} from '@openint/engine-frontend'
 import {SchemaForm, useToast} from '@openint/ui'
@@ -157,7 +158,11 @@ export default function MagicLinkPage() {
           onSubmit={({formData: values}) => {
             createMagicLink.mutate(values, {
               onSuccess: async (data) => {
-                await copyToClipboard(data.url)
+                if (isMainPreview) {
+                  window.location.href = data.url
+                } else {
+                  await copyToClipboard(data.url)
+                }
                 toast({
                   title: 'Magic link copied to clipboard',
                   variant: 'success',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Navigate to magic link URL in `MagicLinkPage` if `isMainPreview` is true, otherwise copy to clipboard.
> 
>   - **Behavior**:
>     - In `MagicLinkPage`, if `isMainPreview` is true, navigate to `data.url` instead of copying it to clipboard.
>   - **Constants**:
>     - Add `isMainPreview` to `constants.ts` to check if the server URL includes 'openint-git-main-openint-dev.vercel.app'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 73e6e8f2b0dd1f5bd825ed7ffc486fedcf425534. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->