### PR TITLE
Adding Drive group Id to listFiles

### DIFF
--- a/kits/cdk/internal/remote-procedure.ts
+++ b/kits/cdk/internal/remote-procedure.ts
@@ -67,7 +67,7 @@ export async function getRemoteContext(ctx: ProtectedContext) {
           return nangoConnectionWithCredentials.parse(r.data)
         })
         .catch((error) => {
-          console.error('nangoConnectionWithCredentials error', error)
+          console.error('Refresh credentials error', error.message)
           throw error
         }),
     }),

--- a/kits/sdk/openapi.json
+++ b/kits/sdk/openapi.json
@@ -7809,6 +7809,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "drive_group_id",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/kits/sdk/openapi.types.d.ts
+++ b/kits/sdk/openapi.types.d.ts
@@ -5908,6 +5908,7 @@ export interface operations {
         page_size?: number
         drive_id?: string
         folder_id?: string
+        drive_group_id?: string
       }
     }
     responses: {

--- a/unified/unified-file-storage/adapters/sharepoint-adapter/index.ts
+++ b/unified/unified-file-storage/adapters/sharepoint-adapter/index.ts
@@ -294,7 +294,9 @@ export const sharepointAdapter = {
 
       const drivesResult = await sharepointAdapter.listDrives({
         instance,
-        input: {},
+        input: {
+          drive_group_id: input?.drive_group_id,
+        },
         ctx,
       })
 

--- a/unified/unified-file-storage/router.ts
+++ b/unified/unified-file-storage/router.ts
@@ -43,6 +43,7 @@ export const fileStorageRouter = trpc.router({
         .extend({
           drive_id: z.string().optional(),
           folder_id: z.string().optional(),
+          drive_group_id: z.string().optional(),
         })
         .nullish(),
     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `drive_group_id` parameter to `listFiles` for filtering by drive group ID in file storage.
> 
>   - **Behavior**:
>     - Add `drive_group_id` query parameter to `listFiles` in `openapi.json` and `openapi.types.d.ts`.
>     - Update `listFiles` in `router.ts` to accept `drive_group_id`.
>     - Modify `listFiles` in `sharepoint-adapter/index.ts` to handle `drive_group_id` when listing files.
>   - **Logging**:
>     - Update error message in `getRemoteContext()` in `remote-procedure.ts` to "Refresh credentials error".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 5a17be57e3299c74a5232601864e8edbcd83fe03. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->