### PR TITLE
removing custom cache keys

### DIFF
--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -18,16 +18,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: true
+      - name: Install dependencies
+        run: pnpm install
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -35,9 +35,12 @@ jobs:
     needs: install-dependencies
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
@@ -51,9 +54,12 @@ jobs:
     needs: install-dependencies
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
@@ -94,9 +100,12 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       DATABASE_URL: postgres://postgres:password@db.localtest.me:5432/postgres
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
@@ -134,11 +143,14 @@ jobs:
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need more than 1 commit https://www.chromatic.com/docs/github-actions/
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'

--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -36,13 +36,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: true
+      - name: Install dependencies
+        run: pnpm install
       - name: Run type checks
         run: pnpm run typecheck
 
@@ -52,13 +52,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: true
+      - name: Install dependencies
+        run: pnpm install
       - name: Run lint
         run: pnpm run lint
         env:
@@ -95,13 +95,13 @@ jobs:
       DATABASE_URL: postgres://postgres:password@db.localtest.me:5432/postgres
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: true
+      - name: Install dependencies
+        run: pnpm install
       - name: Download environment variables
         run: |
           npm install --global vercel@latest
@@ -137,13 +137,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need more than 1 commit https://www.chromatic.com/docs/github-actions/
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: true
+      - name: Install dependencies
+        run: pnpm install
       - name: Download environment variables
         run: |
           npm install --global vercel@latest

--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -14,37 +14,20 @@ jobs:
   install-dependencies:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    outputs:
-      cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set cache key
-        id: set-cache-key
-        run: echo "cache-key=${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}" >> $GITHUB_OUTPUT
 
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+          cache: 'pnpm'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          run_install: false
-
-      - name: Cache pnpm store
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          run_install: true
 
   typecheck:
     runs-on: ubuntu-latest
@@ -55,14 +38,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
-      - uses: actions/cache@v4
         with:
-          path: ~/.pnpm-store
-          key: ${{ needs.install-dependencies.outputs.cache-key }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - run: pnpm install --frozen-lockfile
+          run_install: true
       - name: Run type checks
         run: pnpm run typecheck
 
@@ -75,14 +54,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
-      - uses: actions/cache@v4
         with:
-          path: ~/.pnpm-store
-          key: ${{ needs.install-dependencies.outputs.cache-key }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - run: pnpm install --frozen-lockfile
+          run_install: true
       - name: Run lint
         run: pnpm run lint
         env:
@@ -122,14 +97,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
-      - uses: actions/cache@v4
         with:
-          path: ~/.pnpm-store
-          key: ${{ needs.install-dependencies.outputs.cache-key }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - run: pnpm install --frozen-lockfile
+          run_install: true
       - name: Download environment variables
         run: |
           npm install --global vercel@latest
@@ -168,14 +139,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
-      - uses: actions/cache@v4
         with:
-          path: ~/.pnpm-store
-          key: ${{ needs.install-dependencies.outputs.cache-key }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - run: pnpm install --frozen-lockfile
+          run_install: true
       - name: Download environment variables
         run: |
           npm install --global vercel@latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removed custom cache keys in GitHub Actions workflow, using built-in pnpm cache support for simplification.
> 
>   - **Caching**:
>     - Removed custom cache key setup and usage in `parallel-workflow-validate.yml`.
>     - Utilized built-in `pnpm` cache support in `install-dependencies`, `typecheck`, `lint`, `tests`, and `storybook` jobs.
>   - **Workflow Simplification**:
>     - Removed `actions/cache@v4` steps and related cache key logic.
>     - Simplified `pnpm` installation steps by using `cache: 'pnpm'` in `setup-node` action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 1c479f256ea10c859fa48802f8d3af5f8eaa178b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->