### PR TITLE
Update expand to be comma separated string instead of array, update c…

### DIFF
--- a/packages/api-v1/trpc/openapi-to-trpc.spec.ts
+++ b/packages/api-v1/trpc/openapi-to-trpc.spec.ts
@@ -1,0 +1,99 @@
+import type {Id} from '@openint/cdk'
+import {schema} from '@openint/db'
+import {describeEachDatabase} from '@openint/db/__tests__/test-utils'
+import {makeUlid} from '@openint/util'
+import {createApp} from '../app'
+
+const testApiKey = `apikey_${makeUlid()}`
+const testOrgId = `org_${makeUlid()}` as Id['org']
+
+describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
+  let app: ReturnType<typeof createApp>
+
+  beforeAll(async () => {
+    await db.insert(schema.organization).values({
+      id: testOrgId,
+      api_key: testApiKey,
+    })
+
+    await db.insert(schema.connector_config).values({
+      id: `ccfg_google_${makeUlid()}`,
+      org_id: testOrgId,
+      config: {
+        oauth: {
+          client_id: 'client_222',
+          client_secret: 'xxx',
+          scopes:
+            'https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/gmail.readonly',
+        },
+        integrations: {
+          drive: {
+            enabled: true,
+            scopes: 'https://www.googleapis.com/auth/drive',
+          },
+          gmail: {
+            enabled: false,
+            scopes: 'https://www.googleapis.com/auth/gmail.readonly',
+          },
+        },
+      },
+      display_name: 'Test Google Connection',
+      disabled: false,
+      metadata: {
+        createdBy: 'test-suite',
+        version: '1.0',
+      },
+    })
+    app = createApp({db})
+  })
+
+  test('GET /connector-config with expand options array', async () => {
+    const headers = new Headers()
+    headers.set('authorization', `Bearer ${testApiKey}`)
+    headers.set('accept', 'application/json')
+
+    const url = new URL('http://localhost/api/v1/connector-config')
+    url.searchParams.set('expand', 'enabled_integrations,connector')
+
+    const req = new Request(url, {headers})
+
+    const response = await app.handle(req)
+    const result = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(result).toBeTruthy()
+
+    const items = result.items || []
+
+    expect(items[0].integrations).toEqual({
+      drive: {
+        enabled: true,
+        scopes: 'https://www.googleapis.com/auth/drive',
+      },
+    })
+    expect(items[0].connector).toEqual({
+      name: 'google',
+      logo_url:
+        'https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public//_assets/logo-google.svg',
+    })
+  })
+
+  test('GET /connector-config with invalid expand options', async () => {
+    const headers = new Headers()
+    headers.set('authorization', `Bearer ${testApiKey}`)
+    headers.set('accept', 'application/json')
+
+    const url = new URL('http://localhost/api/v1/connector-config')
+    url.searchParams.set('expand', 'foo ')
+
+    const req = new Request(url, {headers})
+
+    const response = await app.handle(req)
+    const result = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(result.issues[0].message).toEqual(
+      'Invalid expand option. Valid options are: connector, enabled_integrations',
+    )
+  })
+})

--- a/packages/api-v1/trpc/openapi-to-trpc.spec.ts
+++ b/packages/api-v1/trpc/openapi-to-trpc.spec.ts
@@ -84,7 +84,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
     headers.set('accept', 'application/json')
 
     const url = new URL('http://localhost/api/v1/connector-config')
-    url.searchParams.set('expand', 'foo ')
+    url.searchParams.set('expand', 'foo')
 
     const req = new Request(url, {headers})
 

--- a/packages/api-v1/trpc/routers/connectorConfig.spec.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.spec.ts
@@ -138,7 +138,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
       role: 'org',
       orgId: 'org_222',
     }).listConnectorConfigs.query({
-      expand: ['enabled_integrations'],
+      expand: 'enabled_integrations',
     })
     expect(res.items).toHaveLength(2)
 
@@ -160,7 +160,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
       role: 'org',
       orgId: 'org_222',
     }).listConnectorConfigs.query({
-      expand: ['connector', 'enabled_integrations'],
+      expand: 'connector,enabled_integrations',
     })
 
     const googleConnector = res.items.find(

--- a/packages/api-v1/trpc/routers/connectorConfig.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.ts
@@ -123,11 +123,7 @@ export const connectorConfigRouter = router({
             .transform((val) => val.split(','))
             .refine(
               (items) =>
-                items.every((item) =>
-                  zExpandOptions.options.includes(
-                    item as 'connector' | 'enabled_integrations',
-                  ),
-                ),
+                items.every((item) => zExpandOptions.safeParse(item).success),
               {
                 message:
                   'Invalid expand option. Valid options are: connector, enabled_integrations',


### PR DESCRIPTION
…urrent and add new test for openapi
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `expand` parameter in `connectorConfigRouter` to be a comma-separated string, with updated tests for validation and functionality.
> 
>   - **Behavior**:
>     - Update `expand` parameter in `connectorConfigRouter` to be a comma-separated string instead of an array in `connectorConfig.ts`.
>     - Add validation for `expand` options to ensure they are valid, with error message for invalid options.
>   - **Tests**:
>     - Add new test in `openapi-to-trpc.spec.ts` for `GET /connector-config` with valid and invalid `expand` options.
>     - Update `connectorConfig.spec.ts` to use comma-separated `expand` string in `listConnectorConfigs.query()` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for aa50adb01c958367af6f1982edbafacacfc48ca4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->