### PR TITLE
fixing delimeter hardcoding for webhooks

### DIFF
--- a/apps/web/inngest/index.ts
+++ b/apps/web/inngest/index.ts
@@ -14,7 +14,7 @@ const inngestFunctions = [
   // @see https://discord.com/channels/842170679536517141/1214066130860118087/1214283616327180318
   ...Object.keys(outgoingWebhookEventMap).map((name) =>
     inngest.createFunction(
-      {id: `send-webhook/${name}`},
+      {id: `send-webhook.${name}`},
       {event: name as keyof Events},
       sendWebhook,
     ),

--- a/apps/web/inngest/index.ts
+++ b/apps/web/inngest/index.ts
@@ -2,7 +2,7 @@ import type {ServeHandlerOptions} from 'inngest'
 import {serve} from 'inngest/next'
 import {inngest} from '@openint/engine-backend/inngest'
 import type {Events} from '@openint/events'
-import {outgoingWebhookEventMap} from '@openint/events'
+import {eventMapForInngest} from '@openint/events'
 import {withLog} from '@openint/util'
 // import * as functions from './functions'
 import {sendWebhook} from './routines'
@@ -12,7 +12,7 @@ const inngestFunctions = [
   // MARK: - Workaround for Inngest not having support for
   // multiple event triggers in a single function
   // @see https://discord.com/channels/842170679536517141/1214066130860118087/1214283616327180318
-  ...Object.keys(outgoingWebhookEventMap).map((name) =>
+  ...Object.keys(eventMapForInngest).map((name) =>
     inngest.createFunction(
       {id: `send-webhook.${name}`},
       {event: name as keyof Events},

--- a/apps/web/inngest/routines.ts
+++ b/apps/web/inngest/routines.ts
@@ -1,6 +1,7 @@
 import {backendEnv, contextFactory} from '@openint/app-config/backendConfig'
 import {env} from '@openint/app-config/env'
 import '@openint/app-config/register.node'
+import {createClerkClient} from '@clerk/nextjs/server'
 import type {SendEventPayload} from 'inngest/helpers/types'
 import {flatRouter} from '@openint/engine-backend'
 import type {Events, OrgProperties} from '@openint/events'
@@ -86,14 +87,35 @@ export async function syncPipeline({
 }
 
 export async function sendWebhook({event}: FunctionInput<keyof Events>) {
-  if (!event.user?.webhook_url) {
+  console.log('Sending webhook', event)
+
+  const clerkSecretKey = process.env['CLERK_SECRET_KEY']
+  const clerk = createClerkClient({secretKey: clerkSecretKey})
+
+  const organizationId = event?.data.user?.org_id
+
+  if (!organizationId) {
+    console.error('No organization id found', event)
     return false
   }
+
+  // TODO: migrate webhook_url to database
+  const organization = await clerk.organizations.getOrganization({
+    organizationId,
+  })
+  const webhookUrl =
+    event.data.user?.webhook_url ||
+    organization?.publicMetadata?.['webhook_url']
+  if (!webhookUrl) {
+    return false
+  }
+
+  console.log('Sending webhook to', webhookUrl)
 
   // We shall let inngest handle the retries and backoff for now
   // Would be nice to have a openSDK for sending webhook payloads that are typed actually, after all it has
   // the exact same shape as paths.
-  const res = await fetch(event.user.webhook_url, {
+  const res = await fetch(webhookUrl as string, {
     method: 'POST',
     body: JSON.stringify(event),
     headers: {
@@ -102,7 +124,7 @@ export async function sendWebhook({event}: FunctionInput<keyof Events>) {
     },
   })
   const responseAsJson = await responseToJson(res)
-  return {...responseAsJson, target: event.user.webhook_url}
+  return {...responseAsJson, target: webhookUrl}
 }
 
 async function responseToJson(res: Response) {

--- a/packages/api/appRouter.ts
+++ b/packages/api/appRouter.ts
@@ -7,7 +7,7 @@ import {generateOpenApiDocument} from '@lilyrose2798/trpc-openapi/dist/generator
 import {getServerUrl} from '@openint/app-config/constants'
 import {flatRouter} from '@openint/engine-backend'
 import {env} from '@openint/env'
-import {outgoingWebhookEventMap} from '@openint/events'
+import {eventMapForInngest} from '@openint/events'
 import accountingRouter from '@openint/unified-accounting'
 import atsRouter from '@openint/unified-ats'
 import bankingRouter from '@openint/unified-banking'
@@ -114,7 +114,7 @@ function setDefaultOpenAPIMeta(router: AnyRouter) {
 }
 
 export function getOpenAPISpec(includeInternal = true) {
-  const {webhooks, components} = oasWebhooksEventsMap(outgoingWebhookEventMap)
+  const {webhooks, components} = oasWebhooksEventsMap(eventMapForInngest)
 
   let oas = generateOpenApiDocument(appRouter as any, {
     openApiVersion: '3.1.0', // Want jsonschema

--- a/packages/engine-backend/router/customerRouter.ts
+++ b/packages/engine-backend/router/customerRouter.ts
@@ -446,13 +446,23 @@ export const customerRouter = trpc.router({
 
         await ctx.inngest.send({
           name: 'connect.connection-connected',
-          data: {connectionId},
+          data: {
+            connectionId,
+            user: {
+              org_id: ctx.viewer.orgId,
+            },
+          },
         })
 
         if (syncInBackground) {
           await ctx.inngest.send({
             name: 'sync.connection-requested',
-            data: {connectionId},
+            data: {
+              connectionId,
+              user: {
+                org_id: ctx.viewer.orgId,
+              },
+            },
           })
         }
         console.log(

--- a/packages/engine-backend/services/sync-service.ts
+++ b/packages/engine-backend/services/sync-service.ts
@@ -432,8 +432,9 @@ export function makeSyncService({
         destination_id: dest.id,
         customer_id: customerId,
       },
-      user: {webhook_url: org?.webhook_url || ''},
+      user: {org_id: src.connectorConfig.orgId},
     })
+
     // console.log('res', res)
     return {
       pipeline_id: pipeline.id,

--- a/packages/engine-backend/services/sync-service.ts
+++ b/packages/engine-backend/services/sync-service.ts
@@ -1,5 +1,4 @@
 // Amadeo Q: how do I make the atsLink part of the openint/cdk? is there some sort of release process? A: We don't. cdk stands for connector development kit and atsLink does not belong
-import {createClerkClient} from '@clerk/nextjs/server'
 import type {Link as FetchLink} from '@opensdks/runtime'
 import type {
   AnyEntityPayload,
@@ -20,7 +19,6 @@ import {
   singleTableLink,
   sync,
 } from '@openint/cdk'
-import {env} from '@openint/env'
 import type {z} from '@openint/util'
 import {rxjs} from '@openint/util'
 import {unifiedAccountingLink} from '../../../unified/unified-accounting/unifiedAccountingLink'
@@ -38,11 +36,6 @@ import type {
 } from './dbService'
 import type {makeMetaLinks} from './makeMetaLinks'
 import type {MetaService} from './metaService'
-
-const clerkClient = createClerkClient({
-  secretKey: env.CLERK_SECRET_KEY,
-  publishableKey: env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
-})
 
 export function makeSyncService({
   metaLinks,
@@ -344,15 +337,6 @@ export function makeSyncService({
     // TODO: Should we introduce customerId onto the pipeline itself?
     const customerId = src.customerId ?? dest.customerId
     const customer = customerId ? {id: customerId} : null
-
-    // TODO: Maybe not the best place for this? Think where clerkClient should live
-    const org =
-      opts.org ??
-      (await clerkClient.organizations
-        .getOrganization({
-          organizationId: src.connectorConfig.orgId,
-        })
-        .then((r) => r.publicMetadata as {webhook_url?: string | null}))
 
     // console.log('[_syncPipeline] pipe sourceState', pipe.id, pipe.sourceState)
 

--- a/packages/events/events.ts
+++ b/packages/events/events.ts
@@ -80,10 +80,7 @@ export const eventMapForInngest = R.mapValues(eventMap, (v) => ({
   }
 }
 
-/** slash in name is not supported in openapi spec. Plus we don't want to send all events to orgs for now */
-export const outgoingWebhookEventMap = R.omitBy(eventMapForInngest, (_, name) =>
-  name.includes('/'),
-)
+export const outgoingWebhookEventMap = eventMapForInngest
 
 export type Events = Combine<
   BuiltInEvents,

--- a/packages/events/events.ts
+++ b/packages/events/events.ts
@@ -79,6 +79,11 @@ export const eventMapForInngest = R.mapValues(eventMap, (v) => ({
     data: z.ZodObject<(typeof eventMap)[k]>
   }
 }
+
+export const outgoingWebhookEventMap = R.pickBy(eventMapForInngest, (_, name) =>
+  ['connect.connection-connected', 'sync.completed'].includes(name),
+)
+
 export type Events = Combine<
   BuiltInEvents,
   ZodToStandardSchema<typeof eventMapForInngest>

--- a/packages/events/events.ts
+++ b/packages/events/events.ts
@@ -79,9 +79,6 @@ export const eventMapForInngest = R.mapValues(eventMap, (v) => ({
     data: z.ZodObject<(typeof eventMap)[k]>
   }
 }
-
-export const outgoingWebhookEventMap = eventMapForInngest
-
 export type Events = Combine<
   BuiltInEvents,
   ZodToStandardSchema<typeof eventMapForInngest>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace hardcoded webhook event handling with flexible event mapping and update webhook URL retrieval logic.
> 
>   - **Behavior**:
>     - Replace `outgoingWebhookEventMap` with `eventMapForInngest` in `index.ts`, `appRouter.ts`, and `events.ts` to handle webhook events more flexibly.
>     - Update `sendWebhook()` in `routines.ts` to retrieve `webhook_url` from Clerk's organization metadata if not provided in event data.
>     - Modify `customerRouter.ts` to include `org_id` in event data for `connect.connection-connected` and `sync.connection-requested` events.
>   - **Misc**:
>     - Change webhook event ID format in `index.ts` from `send-webhook/{name}` to `send-webhook.{name}`.
>     - Remove unused `createClerkClient` import in `sync-service.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 5a421a709746fe12dace65434c26c5ca5458e0cd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->