### PR TITLE
Readding support for classnames to connect 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,7 +75,6 @@
   "search.exclude": {
     "**/*.generated": true
   },
-  "tailwindCSS.experimental.configFile": "apps/web/tailwind.config.ts",
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "typescript.tsdk": "./node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,

--- a/apps/web/app/debug/page.tsx
+++ b/apps/web/app/debug/page.tsx
@@ -1,7 +1,7 @@
 'use client'
+
 // eslint-disable-next-line import/no-unresolved
 import '@openint/ui-v1/dist/tailwind.css'
-
 import {_trpcReact} from '@openint/engine-frontend'
 import 'next/image'
 // tailwind.css file will be built separately
@@ -13,7 +13,7 @@ import {createQueryClient} from '@/lib-client/react-query-client'
 function DebugInner() {
   const res = _trpcReact.listConnectorMetas.useQuery({})
   return (
-    <div className="flex h-screen w-screen flex-col p-8">
+    <div className="flex h-screen w-screen flex-col p-10">
       <pre>{JSON.stringify(res.data, null, 2)}</pre>
     </div>
   )

--- a/kits/connect/package.json
+++ b/kits/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openint/connect",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/kits/connect/src/embed-react.tsx
+++ b/kits/connect/src/embed-react.tsx
@@ -58,7 +58,7 @@ export const OpenIntConnectEmbed = React.memo(
       // Add a more reliable way to know iframe has fully finished loading
       // by sending message from iframe to parent when ready
       return (
-        <div className="connect-embed-wrapper">
+        <div className={`connect-embed-wrapper ${props.className}`}>
           <div
             className={`spinner-container ${loading ? 'loading' : 'loaded'}`}>
             <svg className="spinner" viewBox="0 0 50 50">

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prettier": "^3.5.3",
     "prettier-plugin-packagejson": "2.5.2",
     "prettier-plugin-sql": "0.18.1",
-    "prettier-plugin-tailwindcss": "0.6.6",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "require-in-the-middle": "7.4.0",
     "ts-brand": "0.0.2",
     "tsx": "3.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
         specifier: 0.18.1
         version: 0.18.1(prettier@3.5.3)
       prettier-plugin-tailwindcss:
-        specifier: 0.6.6
-        version: 0.6.6(@ianvs/prettier-plugin-sort-imports@4.1.1(prettier@3.5.3))(prettier@3.5.3)
+        specifier: ^0.6.11
+        version: 0.6.11(@ianvs/prettier-plugin-sort-imports@4.1.1(prettier@3.5.3))(prettier@3.5.3)
       require-in-the-middle:
         specifier: 7.4.0
         version: 7.4.0
@@ -14605,15 +14605,15 @@ packages:
     peerDependencies:
       prettier: ^3.0.3
 
-  prettier-plugin-tailwindcss@0.6.6:
-    resolution: {integrity: sha512-OPva5S7WAsPLEsOuOWXATi13QrCKACCiIonFgIR6V4lYv4QLp++UXVhZSzRbZxXGimkQtQT86CC6fQqTOybGng==}
+  prettier-plugin-tailwindcss@0.6.11:
+    resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
       '@prettier/plugin-pug': '*'
       '@shopify/prettier-plugin-liquid': '*'
       '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig-melody': '*'
+      '@zackad/prettier-plugin-twig': '*'
       prettier: ^3.0
       prettier-plugin-astro: '*'
       prettier-plugin-css-order: '*'
@@ -14635,7 +14635,7 @@ packages:
         optional: true
       '@trivago/prettier-plugin-sort-imports':
         optional: true
-      '@zackad/prettier-plugin-twig-melody':
+      '@zackad/prettier-plugin-twig':
         optional: true
       prettier-plugin-astro:
         optional: true
@@ -32380,7 +32380,7 @@ snapshots:
       sql-formatter: 15.4.2
       tslib: 2.6.2
 
-  prettier-plugin-tailwindcss@0.6.6(@ianvs/prettier-plugin-sort-imports@4.1.1(prettier@3.5.3))(prettier@3.5.3):
+  prettier-plugin-tailwindcss@0.6.11(@ianvs/prettier-plugin-sort-imports@4.1.1(prettier@3.5.3))(prettier@3.5.3):
     dependencies:
       prettier: 3.5.3
     optionalDependencies:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -24,7 +24,6 @@ module.exports = {
   semi: false,
   singleQuote: true,
   tabWidth: 2,
-  tailwindConfig: './apps/web/tailwind.config.ts',
   trailingComma: 'all',
   useTabs: false,
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-adds `className` support in `OpenIntConnectEmbed`, updates dependencies, and adjusts styles.
> 
>   - **Behavior**:
>     - Re-adds support for `className` prop in `OpenIntConnectEmbed` in `embed-react.tsx`.
>     - Adjusts padding in `DebugInner` component in `page.tsx` from `p-8` to `p-10`.
>   - **Dependencies**:
>     - Updates `prettier-plugin-tailwindcss` version in `package.json`.
>     - Bumps version in `connect/package.json` from `0.2.22` to `0.2.23`.
>   - **Configuration**:
>     - Removes `tailwindConfig` from `prettier.config.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for bc749a6cfc480b67529a981ceb5d5cb0a4dd4afc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->