### PR TITLE
Onboarding flow APIs

### DIFF
--- a/docs/generateDocsOas.bin.cjs
+++ b/docs/generateDocsOas.bin.cjs
@@ -38,7 +38,12 @@ async function getOasSpec() {
 async function main() {
   const oas = await getOasSpec()
 
-  const pathsToFilterOut = ['/health', '/viewer', '/event']
+  const pathsToFilterOut = [
+    '/health',
+    '/viewer',
+    '/event',
+    '/organization/onboarding',
+  ]
 
   const filteredPaths = Object.keys(oas.paths)
     .filter((path) => !pathsToFilterOut.includes(path))

--- a/packages/api-v1/routers/event.spec.ts
+++ b/packages/api-v1/routers/event.spec.ts
@@ -1,0 +1,71 @@
+import type {Viewer} from '@openint/cdk'
+import {schema} from '@openint/db'
+import {describeEachDatabase} from '@openint/db/__tests__/test-utils'
+import {routerContextFromViewer} from '../trpc/context'
+import {eventRouter} from './event'
+
+const logger = false
+
+describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
+  function getCaller(viewer: Viewer) {
+    return eventRouter.createCaller(routerContextFromViewer({db, viewer}))
+  }
+
+  const orgId = 'org_222'
+  const asOrg = getCaller({role: 'org', orgId})
+  const asUser = getCaller({
+    role: 'user',
+    userId: 'user_222',
+    orgId,
+  })
+
+  beforeEach(async () => {
+    await db
+      .insert(schema.organization)
+      .values({
+        id: orgId,
+        name: 'Test Organization',
+        metadata: {},
+      })
+      .onConflictDoNothing()
+  })
+
+  describe('getOnboarding', () => {
+    test('returns correct onboarding state for new organization', async () => {
+      const result = await asOrg.getOnboarding()
+
+      expect(result).toEqual({
+        first_connector_configured: false,
+        first_connection_created: false,
+        api_key_used: false,
+        onboarding_marked_complete: false,
+      })
+    })
+
+    test('user can access organization onboarding state', async () => {
+      const result = await asUser.getOnboarding()
+
+      expect(result).toEqual({
+        first_connector_configured: false,
+        first_connection_created: false,
+        api_key_used: false,
+        onboarding_marked_complete: false,
+      })
+    })
+  })
+
+  describe('setOnboardingComplete', () => {
+    test('marks onboarding as complete', async () => {
+      // Set onboarding complete
+      await asOrg.setOnboardingComplete()
+
+      // Verify onboarding is marked complete
+      const result = await asOrg.getOnboarding()
+      expect(result.onboarding_marked_complete).toBe(true)
+
+      await expect(asOrg.setOnboardingComplete()).rejects.toThrow(
+        'Onboarding already marked complete',
+      )
+    })
+  })
+})

--- a/packages/api-v1/routers/event.ts
+++ b/packages/api-v1/routers/event.ts
@@ -113,8 +113,8 @@ export const eventRouter = router({
       return {
         first_connector_configured: connectorConfigs.length > 0,
         first_connection_created: !!firstConnectionCreated,
-        api_key_used: !!org.metadata.api_key_used,
-        onboarding_marked_complete: !!org.metadata.onboarding_marked_complete,
+        api_key_used: !!org?.metadata?.api_key_used,
+        onboarding_marked_complete: !!org?.metadata?.onboarding_marked_complete,
       }
     }),
 
@@ -145,7 +145,7 @@ export const eventRouter = router({
         })
       }
 
-      if (org.metadata.onboarding_marked_complete) {
+      if (org?.metadata?.onboarding_marked_complete) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Onboarding already marked complete',

--- a/packages/api-v1/routers/event.ts
+++ b/packages/api-v1/routers/event.ts
@@ -1,12 +1,21 @@
-import {schema, sql} from '@openint/db'
-import {publicProcedure, router} from '../trpc/_base'
+import {TRPCError} from '@trpc/server'
+import {z} from 'zod'
+import {eq, inArray, schema, sql} from '@openint/db'
 import {core} from '../models'
+import {publicProcedure, router} from '../trpc/_base'
 import {
   applyPaginationAndOrder,
   processPaginatedResponse,
   zListParams,
   zListResponse,
 } from './utils/pagination'
+
+const zOnboardingState = z.object({
+  first_connector_configured: z.boolean(),
+  first_connection_created: z.boolean(),
+  api_key_used: z.boolean(),
+  onboarding_marked_complete: z.boolean(),
+})
 
 export const eventRouter = router({
   // NOTE: why publish this API?
@@ -54,5 +63,105 @@ export const eventRouter = router({
         limit,
         offset,
       }
+    }),
+
+  getOnboarding: publicProcedure
+    .meta({
+      openapi: {method: 'GET', path: '/organization/onboarding'},
+    })
+    .input(z.void())
+    .output(zOnboardingState)
+    .query(async ({ctx}) => {
+      if (!ctx.viewer.orgId) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'Organization not found',
+        })
+      }
+
+      const org = await ctx
+        .as({role: 'system'})
+        .db.query.organization.findFirst({
+          where: eq(schema.organization.id, ctx.viewer.orgId),
+        })
+
+      if (!org) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Organization not found',
+        })
+      }
+
+      const connectorConfigs = await ctx
+        .as({role: 'system'})
+        .db.query.connector_config.findMany({
+          where: eq(schema.connector_config.org_id, org.id),
+        })
+
+      const firstConnectionCreated =
+        connectorConfigs.length > 0 &&
+        (await ctx.as({role: 'system'}).db.query.connection.findFirst({
+          where:
+            connectorConfigs.length > 0
+              ? inArray(
+                  schema.connection.connector_config_id,
+                  connectorConfigs.map((config) => config.id),
+                )
+              : undefined,
+        }))
+
+      return {
+        first_connector_configured: connectorConfigs.length > 0,
+        first_connection_created: !!firstConnectionCreated,
+        api_key_used: !!org.metadata.api_key_used,
+        onboarding_marked_complete: !!org.metadata.onboarding_marked_complete,
+      }
+    }),
+
+  setOnboardingComplete: publicProcedure
+    .meta({
+      openapi: {method: 'PUT', path: '/organization/onboarding'},
+    })
+    .input(z.void())
+    .output(z.void())
+    .mutation(async ({ctx}) => {
+      if (!ctx.viewer.orgId) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'Organization not found',
+        })
+      }
+
+      const org = await ctx
+        .as({role: 'system'})
+        .db.query.organization.findFirst({
+          where: eq(schema.organization.id, ctx.viewer.orgId),
+        })
+
+      if (!org) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Organization not found',
+        })
+      }
+
+      if (org.metadata.onboarding_marked_complete) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Onboarding already marked complete',
+        })
+      }
+
+      await ctx
+        .as({role: 'system'})
+        .db.update(schema.organization)
+        .set({
+          metadata: {
+            ...org.metadata,
+            onboarding_marked_complete: true,
+          },
+          updated_at: new Date().toISOString(),
+        })
+        .where(eq(schema.organization.id, org.id))
     }),
 })

--- a/packages/api-v1/trpc/authentication.ts
+++ b/packages/api-v1/trpc/authentication.ts
@@ -26,7 +26,7 @@ export async function viewerFromRequest(
     if (!org) {
       throw new TRPCError({code: 'UNAUTHORIZED', message: 'Invalid API key'})
     }
-    if (!org.metadata.api_key_used) {
+    if (!org?.metadata?.api_key_used) {
       await ctx.db.update(schema.organization).set({
         metadata: {
           ...org.metadata,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add onboarding flow APIs with tests, update OpenAPI spec, and modify authentication to track API key usage.
> 
>   - **APIs**:
>     - Add `getOnboarding` and `setOnboardingComplete` procedures to `event.ts` for managing organization onboarding state.
>     - `getOnboarding` returns onboarding state; `setOnboardingComplete` marks onboarding as complete.
>   - **Tests**:
>     - Add `event.spec.ts` to test `getOnboarding` and `setOnboardingComplete` procedures.
>     - Tests cover onboarding state retrieval and completion marking.
>   - **OpenAPI**:
>     - Update `generateDocsOas.bin.cjs` to exclude `/organization/onboarding` from OpenAPI spec.
>   - **Authentication**:
>     - Modify `viewerFromRequest` in `authentication.ts` to update `api_key_used` metadata when API key is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for d1483192869de4a9f549d34f4d2e0cc8136b083a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->