### PR TITLE
Fixing Clerk application hooks error

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,17 +1,17 @@
 import '@openint/ui-v1/global.css'
 import {ClerkProvider} from '@clerk/nextjs'
 // import {TRPCProvider} from '@openint/engine-frontend'
-import React from 'react'
+import React, {Suspense} from 'react'
 import {ClientRootWithClerk} from '@/components/ClientRoot'
+import {Spinner} from '@openint/open-file-picker/src/components/Spinner'
 
 export default function AdminLayout(props: {children: React.ReactNode}) {
-  console.log('[AdminLayout] rendering')
-  // We only get the viewer from cookies to be consistent with how it works
-  // createBrowserSupabaseClient which only uses cookie and does not use header etc.
 
   return (
-    <ClerkProvider>
-      <ClientRootWithClerk>{props.children}</ClientRootWithClerk>
-    </ClerkProvider>
+    <Suspense fallback={<Spinner />}>
+      <ClerkProvider dynamic>
+        <ClientRootWithClerk>{props.children}</ClientRootWithClerk>
+      </ClerkProvider>
+    </Suspense>
   )
 }

--- a/apps/web/components/ClientRoot.tsx
+++ b/apps/web/components/ClientRoot.tsx
@@ -21,7 +21,7 @@ export function ClientRootWithClerk(props: {
   initialAccessToken?: string | null
 }) {
   const auth = useAuth()
-  const status: AsyncStatus = auth.isLoaded ? 'loading' : 'success'
+  const status: AsyncStatus = auth.isLoaded ? 'success' : 'loading'
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
   ;(globalThis as any).auth = auth
@@ -54,8 +54,6 @@ export function ClientRoot({
   authStatus: AsyncStatus
 }) {
   const pathname = usePathname()
-
-  console.log('[ClientRoot] rendering initialToken?', accessToken != null)
 
   const viewer = React.useMemo(
     () => zViewerFromUnverifiedJwtToken.parse(accessToken),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Clerk application hooks by simplifying `Sidebar` and `AuthedLayout`, removing unused organization-specific logic, and improving component structure.
> 
>   - **Behavior**:
>     - Removed `hasPgConnection` logic from `Sidebar` in `Sidebar.tsx`.
>     - Simplified `AuthedLayout` in `layout.tsx` by removing unused hooks and logic related to organization switching.
>     - Removed organization-specific layouts and pages in `org/[slug]/layout.tsx` and `org/[slug]/page.tsx`.
>   - **Components**:
>     - Added `Suspense` with `Spinner` fallback in `AdminLayout` in `layout.tsx`.
>     - Updated `ClientRootWithClerk` in `ClientRoot.tsx` to correctly set `authStatus`.
>   - **Misc**:
>     - Removed `useRefetchOnSwitch` import and usage in `layout.tsx`.
>     - Deleted `layout-client.tsx` and `layout.tsx` in `org/[slug]` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for b37adccc547194b2008fa408d1e026b481461dda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->