### PR TITLE
Ccfgs list page

### DIFF
--- a/apps/web/app/(v1)/console/connector-config/client.tsx
+++ b/apps/web/app/(v1)/console/connector-config/client.tsx
@@ -1,7 +1,16 @@
 'use client'
 
+import Image from 'next/image'
 import {use} from 'react'
 import type {core} from '@openint/api-v1/models'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@openint/shadcn/ui/table'
 import {useSuspenseQuery} from '@openint/ui-v1/trpc'
 import type {z} from '@openint/util'
 import {useTRPC} from '../client'
@@ -18,7 +27,7 @@ export function ConnectorConfigList(props: {
   const trpc = useTRPC()
   const res = useSuspenseQuery(
     trpc.listConnectorConfigs.queryOptions(
-      {expand: 'enabled_integrations'},
+      {expand: 'enabled_integrations,connector'},
       (initialData ? {initialData} : undefined) as never,
     ),
   )
@@ -26,21 +35,84 @@ export function ConnectorConfigList(props: {
   const connectorConfigs = res.data.items
 
   return (
-    <ul>
-      {connectorConfigs.map((connectorConfig) => (
-        <li key={connectorConfig.id} className="ml-4 list-disc">
-          <pre className="overflow-auto rounded bg-gray-100 p-4">
-            {JSON.stringify(connectorConfig, null, 2)}
-          </pre>
-        </li>
-      ))}
-      {res.isFetching && <em>Loading...</em>}
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Connector Name</TableHead>
+            <TableHead>Created At</TableHead>
+            <TableHead>Updated At</TableHead>
+            <TableHead>Config</TableHead>
+            <TableHead>Integrations</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {connectorConfigs.map((ccfg) => (
+            <TableRow key={ccfg.id}>
+              <TableCell>
+                <div className="flex items-center space-x-2">
+                  {ccfg.connector?.logo_url ? (
+                    <Image
+                      src={ccfg.connector.logo_url}
+                      alt={`${ccfg.connector_name} logo`}
+                      width={32}
+                      height={32}
+                      className="object-contain"
+                    />
+                  ) : (
+                    <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-200">
+                      <span className="text-xs text-gray-500">
+                        {ccfg.connector_name.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                  )}
+                  <span>
+                    {ccfg.connector_name.charAt(0).toUpperCase() +
+                      ccfg.connector_name.slice(1)}
+                  </span>
+                </div>
+              </TableCell>
+              <TableCell>
+                {new Date(ccfg.created_at).toLocaleString()}
+              </TableCell>
+              <TableCell>
+                {new Date(ccfg.updated_at).toLocaleString()}
+              </TableCell>
+              <TableCell>
+                <details>
+                  <summary className="cursor-pointer text-sm text-blue-600">
+                    View
+                  </summary>
+                  <pre className="mt-2 max-h-60 overflow-auto rounded bg-gray-50 p-2 text-xs">
+                    {JSON.stringify(ccfg.config, null, 2)}
+                  </pre>
+                </details>
+              </TableCell>
+              <TableCell>
+                {ccfg.integrations ? (
+                  <details>
+                    <summary className="cursor-pointer text-sm text-blue-600">
+                      View
+                    </summary>
+                    <pre className="mt-2 max-h-60 overflow-auto rounded bg-gray-50 p-2 text-xs">
+                      {JSON.stringify(ccfg.integrations, null, 2)}
+                    </pre>
+                  </details>
+                ) : (
+                  <span className="text-gray-400">None</span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
       <button
         onClick={() => res.refetch()}
         className="mt-4 rounded bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600"
         disabled={res.isFetching}>
         {res.isFetching ? 'Refreshing...' : 'Refresh Connector Configs'}
       </button>
-    </ul>
+    </div>
   )
 }

--- a/apps/web/app/(v1)/console/connector-config/client.tsx
+++ b/apps/web/app/(v1)/console/connector-config/client.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import {use} from 'react'
+import type {core} from '@openint/api-v1/models'
+import {useSuspenseQuery} from '@openint/ui-v1/trpc'
+import type {z} from '@openint/util'
+import {useTRPC} from '../client'
+
+export function ConnectorConfigList(props: {
+  initialData?: Promise<{
+    items: Array<z.infer<typeof core.connector_config>>
+    total: number
+    limit: number
+    offset: number
+  }>
+}) {
+  const initialData = use(props.initialData ?? Promise.resolve(undefined))
+  const trpc = useTRPC()
+  const res = useSuspenseQuery(
+    trpc.listConnectorConfigs.queryOptions(
+      {expand: 'enabled_integrations'},
+      (initialData ? {initialData} : undefined) as never,
+    ),
+  )
+
+  const connectorConfigs = res.data.items
+
+  return (
+    <ul>
+      {connectorConfigs.map((connectorConfig) => (
+        <li key={connectorConfig.id} className="ml-4 list-disc">
+          <pre className="overflow-auto rounded bg-gray-100 p-4">
+            {JSON.stringify(connectorConfig, null, 2)}
+          </pre>
+        </li>
+      ))}
+      {res.isFetching && <em>Loading...</em>}
+      <button
+        onClick={() => res.refetch()}
+        className="mt-4 rounded bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600"
+        disabled={res.isFetching}>
+        {res.isFetching ? 'Refreshing...' : 'Refresh Connector Configs'}
+      </button>
+    </ul>
+  )
+}

--- a/apps/web/app/(v1)/console/connector-config/page.tsx
+++ b/apps/web/app/(v1)/console/connector-config/page.tsx
@@ -1,0 +1,29 @@
+import {Suspense} from 'react'
+import type {PageProps} from '@/lib-common/next-utils'
+import {currentViewer} from '@/lib-server/auth.server'
+import {createAPICaller} from '@/lib-server/globals'
+import {ClientApp} from '../client'
+
+function Fallback() {
+  return <div>Loading...</div>
+}
+
+export default async function Page(props: PageProps) {
+  const {viewer, token = ''} = await currentViewer(props)
+
+  const api = createAPICaller(viewer)
+  const connectorConfigs = await api.listConnectorConfigs({
+    expand: 'enabled_integrations',
+  })
+
+  return (
+    <div>
+      <ClientApp token={token}>
+        <h1>Connector Configs</h1>
+        <Suspense fallback={<Fallback />}>
+          <pre>{JSON.stringify(connectorConfigs.items, null, 2)}</pre>
+        </Suspense>
+      </ClientApp>
+    </div>
+  )
+}

--- a/apps/web/app/(v1)/console/connector-config/page.tsx
+++ b/apps/web/app/(v1)/console/connector-config/page.tsx
@@ -3,6 +3,7 @@ import type {PageProps} from '@/lib-common/next-utils'
 import {currentViewer} from '@/lib-server/auth.server'
 import {createAPICaller} from '@/lib-server/globals'
 import {ClientApp} from '../client'
+import {ConnectorConfigList} from './client'
 
 function Fallback() {
   return <div>Loading...</div>
@@ -12,16 +13,17 @@ export default async function Page(props: PageProps) {
   const {viewer, token = ''} = await currentViewer(props)
 
   const api = createAPICaller(viewer)
-  const connectorConfigs = await api.listConnectorConfigs({
-    expand: 'enabled_integrations',
-  })
 
   return (
     <div>
       <ClientApp token={token}>
         <h1>Connector Configs</h1>
         <Suspense fallback={<Fallback />}>
-          <pre>{JSON.stringify(connectorConfigs.items, null, 2)}</pre>
+          <ConnectorConfigList
+            initialData={api.listConnectorConfigs({
+              expand: 'enabled_integrations',
+            })}
+          />
         </Suspense>
       </ClientApp>
     </div>

--- a/connectors/connector-greenhouse/def.ts
+++ b/connectors/connector-greenhouse/def.ts
@@ -19,6 +19,8 @@ export const greenhouseSchema = {
   ]),
   // need better typing...!
   sourceState: z.unknown(),
+  // TODO: @rodri77 - adding config empty object for now, might not be needed
+  connectorConfig: z.object({}),
 } satisfies ConnectorSchemas
 
 export const greenhouseHelpers = connHelpers(greenhouseSchema)

--- a/connectors/connector-greenhouse/def.ts
+++ b/connectors/connector-greenhouse/def.ts
@@ -19,8 +19,6 @@ export const greenhouseSchema = {
   ]),
   // need better typing...!
   sourceState: z.unknown(),
-  // TODO: @rodri77 - adding config empty object for now, might not be needed
-  connectorConfig: z.object({}),
 } satisfies ConnectorSchemas
 
 export const greenhouseHelpers = connHelpers(greenhouseSchema)

--- a/packages/api-v1/routers/connectorConfig.spec.ts
+++ b/packages/api-v1/routers/connectorConfig.spec.ts
@@ -155,6 +155,19 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
     })
   })
 
+  test('list connector config with expand connection_count', async () => {
+    const res = await getClient({
+      role: 'org',
+      orgId: 'org_222',
+    }).listConnectorConfigs.query({
+      expand: 'connection_count',
+    })
+    expect(res.items).toHaveLength(2)
+
+    expect(res.items[0]?.connection_count).toEqual(0)
+    expect(res.items[1]?.connection_count).toEqual(0)
+  })
+
   test('list connector config with expand connector and enabled_integrations', async () => {
     const res = await getClient({
       role: 'org',

--- a/packages/api-v1/routers/connectorConfig.ts
+++ b/packages/api-v1/routers/connectorConfig.ts
@@ -4,8 +4,8 @@ import {defConnectors} from '@openint/all-connectors/connectors.def'
 import {makeId} from '@openint/cdk'
 import {and, eq, schema, sql} from '@openint/db'
 import {makeUlid} from '@openint/util'
-import {authenticatedProcedure, orgProcedure, router} from '../trpc/_base'
 import {core} from '../models'
+import {authenticatedProcedure, orgProcedure, router} from '../trpc/_base'
 import {
   applyPaginationAndOrder,
   processPaginatedResponse,
@@ -174,6 +174,10 @@ export const connectorConfigRouter = router({
             const result = {...ccfg} as z.infer<
               typeof connectorConfigWithRelations
             >
+
+            if (result.config && Object.keys(result.config).length === 0) {
+              result.config = null
+            }
 
             if (expandOptions.includes('connector')) {
               const connector = expandConnector(ccfg)

--- a/packages/api-v1/routers/connectorConfig.ts
+++ b/packages/api-v1/routers/connectorConfig.ts
@@ -1,6 +1,4 @@
 import {TRPCError} from '@trpc/server'
-// TODO (@rodri77): Fix this import
-import type {PgSelect} from 'drizzle-orm'
 import {z} from 'zod'
 import {defConnectors} from '@openint/all-connectors/connectors.def'
 import {makeId} from '@openint/cdk'
@@ -108,21 +106,6 @@ const connectorConfigWithRelations = z.intersection(
   }),
 )
 
-function withConnectionCount<T extends PgSelect>(
-  qb: T,
-  includeCount: boolean = false,
-) {
-  if (!includeCount) return qb
-
-  return qb.select({
-    connection_count: sql<number>`(
-      SELECT COUNT(*) 
-      FROM ${schema.connection} 
-      WHERE ${schema.connection.connector_config_id} = ${schema.connector_config.id}
-    )`.as('connection_count'),
-  })
-}
-
 export const connectorConfigRouter = router({
   listConnectorConfigs: authenticatedProcedure
     .meta({
@@ -161,36 +144,38 @@ export const connectorConfigRouter = router({
       const includeConnectionCount = (input?.expand || []).includes(
         'connection_count',
       )
-
-      let query = ctx.db
-        .select({
-          connector_config: schema.connector_config,
-          total: sql`count(*) over ()`,
-        })
-        .from(schema.connector_config)
-        .where(
-          and(
-            input?.connector_name
-              ? eq(schema.connector_config.connector_name, input.connector_name)
-              : undefined,
+      const {query, limit, offset} = applyPaginationAndOrder(
+        ctx.db
+          .select({
+            connector_config: schema.connector_config,
+            total: sql`count(*) over ()`,
+            ...(includeConnectionCount
+              ? {
+                  connection_count: sql<number>`(
+                    SELECT COUNT(*)
+                    FROM ${schema.connection}
+                    WHERE ${schema.connection}.connector_config_id = ${schema.connector_config.id}
+                  )`.as('connection_count'),
+                }
+              : {}),
+          })
+          .from(schema.connector_config)
+          .where(
+            and(
+              input?.connector_name
+                ? eq(
+                    schema.connector_config.connector_name,
+                    input.connector_name,
+                  )
+                : undefined,
+            ),
           ),
-        )
-        .$dynamic()
-
-      query = withConnectionCount(query, includeConnectionCount)
-
-      const {
-        query: finalQuery,
-        limit,
-        offset,
-      } = applyPaginationAndOrder(
-        query,
         schema.connector_config.created_at,
         input,
       )
 
       const {items, total} = await processPaginatedResponse(
-        finalQuery,
+        query,
         'connector_config',
       )
       const expandOptions = (input?.expand || []) as Array<

--- a/packages/api-v1/routers/connectorConfig.ts
+++ b/packages/api-v1/routers/connectorConfig.ts
@@ -147,7 +147,18 @@ export const connectorConfigRouter = router({
       const {query, limit, offset} = applyPaginationAndOrder(
         ctx.db
           .select({
-            connector_config: schema.connector_config,
+            connector_config: {
+              ...schema.connector_config,
+              ...(includeConnectionCount
+                ? {
+                    connection_count: sql<number>`(
+                      SELECT COUNT(*)
+                      FROM ${schema.connection}
+                      WHERE ${schema.connection}.connector_config_id = ${schema.connector_config.id}
+                    )`.as('connection_count'),
+                  }
+                : {}),
+            },
             total: sql`count(*) over ()`,
             ...(includeConnectionCount
               ? {

--- a/packages/api-v1/routers/connectorConfig.ts
+++ b/packages/api-v1/routers/connectorConfig.ts
@@ -160,15 +160,6 @@ export const connectorConfigRouter = router({
                 : {}),
             },
             total: sql`count(*) over ()`,
-            ...(includeConnectionCount
-              ? {
-                  connection_count: sql<number>`(
-                    SELECT COUNT(*)
-                    FROM ${schema.connection}
-                    WHERE ${schema.connection}.connector_config_id = ${schema.connector_config.id}
-                  )`.as('connection_count'),
-                }
-              : {}),
           })
           .from(schema.connector_config)
           .where(

--- a/packages/api-v1/trpc/openapi-to-trpc.spec.ts
+++ b/packages/api-v1/trpc/openapi-to-trpc.spec.ts
@@ -93,7 +93,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
 
     expect(response.status).toBe(400)
     expect(result.issues[0].message).toEqual(
-      'Invalid expand option. Valid options are: connector, enabled_integrations, connecton_count',
+      'Invalid expand option. Valid options are: connector, enabled_integrations, connection_count',
     )
   })
 })

--- a/packages/api-v1/trpc/openapi-to-trpc.spec.ts
+++ b/packages/api-v1/trpc/openapi-to-trpc.spec.ts
@@ -93,7 +93,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
 
     expect(response.status).toBe(400)
     expect(result.issues[0].message).toEqual(
-      'Invalid expand option. Valid options are: connector, enabled_integrations',
+      'Invalid expand option. Valid options are: connector, enabled_integrations, connecton_count',
     )
   })
 })

--- a/packages/db/__tests__/test-utils.ts
+++ b/packages/db/__tests__/test-utils.ts
@@ -147,3 +147,14 @@ export async function getMigrationStatements(
     generateDrizzleJson(imports),
   )
 }
+
+export async function formatSql(sqlString: string) {
+  const prettier = await import('prettier')
+  const prettierSql = await import('prettier-plugin-sql')
+  return prettier.format(sqlString, {
+    parser: 'sql',
+    plugins: [prettierSql.default],
+    // https://github.com/un-ts/prettier/tree/master/packages/sql#sql-in-js-with-prettier-plugin-embed
+    ['language' as 'filepath' /* workaround type error */]: 'postgresql',
+  })
+}

--- a/packages/db/db.ts
+++ b/packages/db/db.ts
@@ -5,7 +5,7 @@ import type {Viewer} from '@openint/cdk'
 import type {initDbNeon} from './db.neon'
 import type {initDbPg, initDbPgDirect} from './db.pg'
 import type {initDbPGLite, initDbPGLiteDirect} from './db.pglite'
-import * as schema from './schema/schema'
+import {schema} from './schema'
 
 // MARK: - For users
 

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,9 +1,8 @@
-import {type Database} from './db'
-import * as schema from './schema/schema'
-
 export * from 'drizzle-orm'
 export type {QueryBuilder} from 'drizzle-orm/pg-core'
+
+export {schema} from './schema'
+export {type Database} from './db'
+
 export * from './lib/stripeNullByte'
 export * from './lib/upsert'
-export {schema}
-export type {Database}

--- a/packages/db/lib/join.spec.ts
+++ b/packages/db/lib/join.spec.ts
@@ -1,0 +1,16 @@
+import {drizzle} from 'drizzle-orm/node-postgres'
+import {formatSql} from '../__tests__/test-utils'
+import {schema} from '../schema'
+
+const db = drizzle('postgres://noop', {logger: false, schema})
+
+test('query with joins', async () => {
+  const query = db.query.connector_config.findMany({
+    with: {
+      connections: true,
+    },
+  })
+  console.log('query', await formatSql(query?.toSQL().sql ?? ''))
+
+  // expect(await formatSql(query?.toSQL().sql ?? '')).toMatchInlineSnapshot()
+})

--- a/packages/db/lib/join.spec.ts
+++ b/packages/db/lib/join.spec.ts
@@ -67,6 +67,7 @@ describeEachDatabase({migrate: true, drivers: ['pglite']}, (db) => {
       with: {
         connections: {
           columns: {id: true},
+          limit: 5,
         },
       },
       extras: {
@@ -101,9 +102,16 @@ describeEachDatabase({migrate: true, drivers: ['pglite']}, (db) => {
               '[]'::json
             ) as "data"
           from
-            "connection" "connector_config_connections"
-          where
-            "connector_config_connections"."connector_config_id" = "connector_config"."id"
+            (
+              select
+                *
+              from
+                "connection" "connector_config_connections"
+              where
+                "connector_config_connections"."connector_config_id" = "connector_config"."id"
+              limit
+                $1
+            ) "connector_config_connections"
         ) "connector_config_connections" on true
       "
     `)

--- a/packages/db/lib/join.spec.ts
+++ b/packages/db/lib/join.spec.ts
@@ -1,16 +1,116 @@
+import {sql} from 'drizzle-orm'
 import {drizzle} from 'drizzle-orm/node-postgres'
-import {formatSql} from '../__tests__/test-utils'
+import {describeEachDatabase, formatSql} from '../__tests__/test-utils'
 import {schema} from '../schema'
 
 const db = drizzle('postgres://noop', {logger: false, schema})
 
-test('query with joins', async () => {
+test('query with t many joins', async () => {
   const query = db.query.connector_config.findMany({
-    with: {
-      connections: true,
-    },
+    with: {connections: true},
   })
-  console.log('query', await formatSql(query?.toSQL().sql ?? ''))
+  // console.log(await formatSql(query?.toSQL().sql ?? ''))
 
-  // expect(await formatSql(query?.toSQL().sql ?? '')).toMatchInlineSnapshot()
+  expect(await formatSql(query?.toSQL().sql ?? '')).toMatchInlineSnapshot(`
+    "select
+      "connector_config"."id",
+      "connector_config"."connector_name",
+      "connector_config"."config",
+      "connector_config"."created_at",
+      "connector_config"."updated_at",
+      "connector_config"."org_id",
+      "connector_config"."display_name",
+      "connector_config"."env_name",
+      "connector_config"."disabled",
+      "connector_config"."default_pipe_out",
+      "connector_config"."default_pipe_in",
+      "connector_config"."default_pipe_out_destination_id",
+      "connector_config"."default_pipe_in_source_id",
+      "connector_config"."metadata",
+      "connector_config_connections"."data" as "connections"
+    from
+      "connector_config"
+      left join lateral (
+        select
+          coalesce(
+            json_agg(
+              json_build_array(
+                "connector_config_connections"."id",
+                "connector_config_connections"."connector_name",
+                "connector_config_connections"."customer_id",
+                "connector_config_connections"."connector_config_id",
+                "connector_config_connections"."integration_id",
+                "connector_config_connections"."env_name",
+                "connector_config_connections"."settings",
+                "connector_config_connections"."created_at",
+                "connector_config_connections"."updated_at",
+                "connector_config_connections"."display_name",
+                "connector_config_connections"."disabled",
+                "connector_config_connections"."metadata"
+              )
+            ),
+            '[]'::json
+          ) as "data"
+        from
+          "connection" "connector_config_connections"
+        where
+          "connector_config_connections"."connector_config_id" = "connector_config"."id"
+      ) "connector_config_connections" on true
+    "
+  `)
+})
+
+describeEachDatabase({migrate: true, drivers: ['pglite']}, (db) => {
+  test('query with count and group by', async () => {
+    const query = db.query.connector_config.findMany({
+      columns: {id: true},
+      with: {
+        connections: {
+          columns: {id: true},
+        },
+      },
+      extras: {
+        connection_count: sql<number>`(
+          SELECT COUNT(*)
+          FROM ${schema.connection}
+          WHERE ${schema.connection}.connector_config_id = ${schema.connector_config.id}
+      )`.as('connection_count'),
+      },
+    })
+
+    expect(await formatSql(query?.toSQL().sql ?? '')).toMatchInlineSnapshot(`
+      "select
+        "connector_config"."id",
+        (
+          SELECT
+            COUNT(*)
+          FROM
+            "connection"
+          WHERE
+            "connection".connector_config_id = "connector_config"."id"
+        ) as "connection_count",
+        "connector_config_connections"."data" as "connections"
+      from
+        "connector_config"
+        left join lateral (
+          select
+            coalesce(
+              json_agg(
+                json_build_array("connector_config_connections"."id")
+              ),
+              '[]'::json
+            ) as "data"
+          from
+            "connection" "connector_config_connections"
+          where
+            "connector_config_connections"."connector_config_id" = "connector_config"."id"
+        ) "connector_config_connections" on true
+      "
+    `)
+    // Ensure query runs witout errors
+    // TODO: Setup some fixture data to ensure that we get a valid response with proper count
+    // and maybe including all connector_config even those with connection_count=0
+    const res = await query
+    expect(res).toBeDefined()
+  })
 })

--- a/packages/db/lib/join.spec.ts
+++ b/packages/db/lib/join.spec.ts
@@ -79,7 +79,27 @@ describeEachDatabase({migrate: true, drivers: ['pglite']}, (db) => {
       env_name: 'sandbox',
     })
   })
-  test('query with count and group by', async () => {
+
+  test('simple count', async () => {
+    const query = db
+      .select({connection_count: sql`count(*)`})
+      .from(schema.connection)
+      .where(
+        sql`${schema.connection}.connector_config_id = ${'ccfg_greenhouse_222'}`,
+      )
+    expect(await formatSql(query?.toSQL().sql ?? '')).toMatchInlineSnapshot(`
+      "select
+        count(*)
+      from
+        "connection"
+      where
+        "connection".connector_config_id = $1
+      "
+    `)
+    expect(await query).toMatchObject([{connection_count: 1}])
+  })
+
+  test('query with count and join', async () => {
     const query = db.query.connector_config.findMany({
       columns: {id: true},
       with: {
@@ -93,7 +113,7 @@ describeEachDatabase({migrate: true, drivers: ['pglite']}, (db) => {
           SELECT COUNT(*)
           FROM ${schema.connection}
           WHERE ${schema.connection}.connector_config_id = ${schema.connector_config.id}
-      )`.as('connection_count'),
+        )`.as('connection_count'),
       },
     })
 

--- a/packages/db/lib/upsert-sql.spec.ts
+++ b/packages/db/lib/upsert-sql.spec.ts
@@ -10,18 +10,8 @@ import {
   serial,
   varchar,
 } from 'drizzle-orm/pg-core'
+import {formatSql} from '../__tests__/test-utils'
 import {dbUpsert, dbUpsertOne, inferTableForUpsert} from './upsert'
-
-async function formatSql(sqlString: string) {
-  const prettier = await import('prettier')
-  const prettierSql = await import('prettier-plugin-sql')
-  return prettier.format(sqlString, {
-    parser: 'sql',
-    plugins: [prettierSql.default],
-    // https://github.com/un-ts/prettier/tree/master/packages/sql#sql-in-js-with-prettier-plugin-embed
-    ['language' as 'filepath' /* workaround type error */]: 'postgresql',
-  })
-}
 
 const noopDb = drizzle('postgres://noop', {logger: false})
 

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -1,0 +1,7 @@
+import * as relations from './relations'
+import * as tables from './schema'
+
+export const schema = {
+  ...tables,
+  ...relations,
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add connector config list page and support for connection count expansion in API.
> 
>   - **Frontend**:
>     - Adds `ConnectorConfigList` component in `client.tsx` to display connector configurations in a table.
>     - Implements `Page` component in `page.tsx` to render the connector config list with suspense for loading state.
>   - **Backend**:
>     - Updates `connectorConfig.ts` to include `connection_count` in `zExpandOptions` and handle it in `listConnectorConfigs` query.
>     - Modifies `connectorConfig.spec.ts` to test listing with `connection_count` expand option.
>   - **Database**:
>     - Adds `formatSql` function in `test-utils.ts` for SQL formatting.
>     - Updates `db.ts` and `index.ts` to export `schema` correctly.
>     - Adds `join.spec.ts` to test SQL queries with joins and counts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 8dbb9930bad036a4732bcae8e222d6a99f7b2675. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->