### PR TITLE
fix(connector): adding pagination to connector

### DIFF
--- a/packages/api-v1/routers/connector.spec.ts
+++ b/packages/api-v1/routers/connector.spec.ts
@@ -17,14 +17,17 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
   test('list connectors', async () => {
     const res = await asOrg.listConnectors()
 
-    expect(res.length).toBeGreaterThan(1)
+    expect(res.items.length).toBeGreaterThan(1)
   })
 
   test('list connectors with integrations', async () => {
-    const res = await asOrg.listConnectors({expand: ['integrations']})
-    const mergeIndex = res.findIndex((c) => c.name === 'merge')
+    const res = await asOrg.listConnectors({
+      expand: ['integrations'],
+      limit: 100,
+    })
+    const mergeIndex = res.items.findIndex((c) => c.name === 'merge')
 
-    expect(res[mergeIndex]?.integrations?.length).toBeGreaterThan(1)
+    expect(res.items[mergeIndex]?.integrations?.length).toBeGreaterThan(1)
   })
 
   test('get connector by with invalid name returns error', async () => {

--- a/packages/api-v1/routers/connector.ts
+++ b/packages/api-v1/routers/connector.ts
@@ -74,7 +74,7 @@ export const connectorRouter = router({
         ) {
           if (isListIntegrationsFunction(server.listIntegrations)) {
             try {
-              const integrations = await server.listIntegrations()
+              const integrations = await server.listIntegrations({})
 
               if (
                 integrations &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add pagination to `listConnectors` in `connector.ts` and update tests in `connector.spec.ts`.
> 
>   - **Behavior**:
>     - Adds pagination to `listConnectors` in `connector.ts` using `limit` and `offset` parameters.
>     - Updates `listConnectors` to return a paginated response with `total`, `items`, `offset`, and `limit`.
>   - **Tests**:
>     - Updates tests in `connector.spec.ts` to check for `items` length instead of array length.
>     - Adds `limit` parameter to `listConnectors` test with integrations.
>   - **Schemas**:
>     - Uses `zListParams` and `zListResponse` for input and output schemas in `connector.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 3cf2e98a82e58756ecdc07fa7a8d19c624595625. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->