### PR TITLE
fixing gh pages

### DIFF
--- a/unified/unified-ats/adapters/greenhouse-adapter/index.ts
+++ b/unified/unified-ats/adapters/greenhouse-adapter/index.ts
@@ -5,45 +5,42 @@ import {mappers} from './mappers'
 
 export const greenhouseAdapter = {
   listJobs: async ({instance, input}) => {
-    const cursor =
-      input?.cursor && Number(input?.cursor) > 0
-        ? Number(input?.cursor)
-        : undefined
+    const page = input?.cursor ? Number(input?.cursor) : 1
+
     const res = await instance.GET('/v1/jobs', {
-      params: {query: {per_page: input?.page_size, page: cursor}},
+      params: {query: {per_page: input?.page_size, page: page}},
     })
-    let nextCursor = undefined
+
+    let nextPage = undefined
     if (input?.page_size && res.data?.length === input?.page_size) {
-      nextCursor = (cursor || 0) + input.page_size
+      nextPage = page + 1
     }
+
     return {
-      has_next_page: !!nextCursor,
-      next_cursor: nextCursor ? String(nextCursor) : undefined,
+      has_next_page: !!nextPage,
+      next_cursor: nextPage ? String(nextPage) : undefined,
       items: res.data?.map((d) => applyMapper(mappers.job, d)) ?? [],
     }
   },
   listJobOpenings: async ({instance, input}) => {
-    const cursor =
-      input?.cursor && Number(input?.cursor) > 0
-        ? Number(input?.cursor)
-        : undefined
+    const page = input?.cursor ? Number(input?.cursor) : 1
     const jobId = input?.jobId
     if (!jobId) {
       throw new Error('jobId is required')
     }
     const res = await instance.GET('/v1/jobs/{id}/openings', {
       params: {
-        query: {per_page: input?.page_size, page: cursor},
+        query: {per_page: input?.page_size, page: page},
         path: {id: jobId},
       },
     })
-    let nextCursor = undefined
+    let nextPage = undefined
     if (input?.page_size && res.data?.length === input?.page_size) {
-      nextCursor = (cursor || 0) + input.page_size
+      nextPage = page + 1
     }
     return {
-      has_next_page: !!nextCursor,
-      next_cursor: nextCursor ? String(nextCursor) : undefined,
+      has_next_page: !!nextPage,
+      next_cursor: nextPage ? String(nextPage) : undefined,
       items:
         res.data?.map((d) =>
           applyMapper(mappers.opening, {job_id: jobId, ...d}),
@@ -51,56 +48,47 @@ export const greenhouseAdapter = {
     }
   },
   listOffers: async ({instance, input}) => {
-    const cursor =
-      input?.cursor && Number(input?.cursor) > 0
-        ? Number(input?.cursor)
-        : undefined
+    const page = input?.cursor ? Number(input?.cursor) : 1
     const res = await instance.GET('/v1/offers', {
-      params: {query: {per_page: input?.page_size, page: cursor}},
+      params: {query: {per_page: input?.page_size, page: page}},
     })
-    let nextCursor = undefined
+    let nextPage = undefined
     if (input?.page_size && res.data?.length === input?.page_size) {
-      nextCursor = (cursor || 0) + input.page_size
+      nextPage = page + 1
     }
     return {
-      has_next_page: !!nextCursor,
-      next_cursor: nextCursor ? String(nextCursor) : undefined,
+      has_next_page: !!nextPage,
+      next_cursor: nextPage ? String(nextPage) : undefined,
       items: res.data?.map((d) => applyMapper(mappers.offer, d)) ?? [],
     }
   },
   listCandidates: async ({instance, input}) => {
-    const cursor =
-      input?.cursor && Number(input?.cursor) > 0
-        ? Number(input?.cursor)
-        : undefined
+    const page = input?.cursor ? Number(input?.cursor) : 1
     const res = await instance.GET('/v1/candidates', {
-      params: {query: {per_page: input?.page_size, page: cursor}},
+      params: {query: {per_page: input?.page_size, page: page}},
     })
-    let nextCursor = undefined
+    let nextPage = undefined
     if (input?.page_size && res.data?.length === input?.page_size) {
-      nextCursor = (cursor || 0) + input.page_size
+      nextPage = page + 1
     }
     return {
-      has_next_page: !!nextCursor,
-      next_cursor: nextCursor ? String(nextCursor) : undefined,
+      has_next_page: !!nextPage,
+      next_cursor: nextPage ? String(nextPage) : undefined,
       items: res.data?.map((d) => applyMapper(mappers.candidate, d)) ?? [],
     }
   },
   listDepartments: async ({instance, input}) => {
-    const cursor =
-      input?.cursor && Number(input?.cursor) > 0
-        ? Number(input?.cursor)
-        : undefined
+    const page = input?.cursor ? Number(input?.cursor) : 1
     const res = await instance.GET('/v1/departments', {
-      params: {query: {per_page: input?.page_size, page: cursor}},
+      params: {query: {per_page: input?.page_size, page: page}},
     })
-    let nextCursor = undefined
+    let nextPage = undefined
     if (input?.page_size && res.data?.length === input?.page_size) {
-      nextCursor = (cursor || 0) + input.page_size
+      nextPage = page + 1
     }
     return {
-      has_next_page: !!nextCursor,
-      next_cursor: nextCursor ? String(nextCursor) : undefined,
+      has_next_page: !!nextPage,
+      next_cursor: nextPage ? String(nextPage) : undefined,
       items: res.data?.map((d) => applyMapper(mappers.department, d)) ?? [],
     }
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactored pagination logic in `greenhouseAdapter` by replacing `cursor` with `page` for more intuitive handling across multiple functions.
> 
>   - **Pagination Logic**:
>     - Replaced `cursor` with `page` for pagination in `listJobs`, `listJobOpenings`, `listOffers`, `listCandidates`, and `listDepartments` in `index.ts`.
>     - Simplified page calculation: `page` defaults to 1 if `input?.cursor` is not provided.
>     - Updated `nextPage` logic to increment `page` by 1 if more pages are available.
>   - **Return Structure**:
>     - Updated `has_next_page` and `next_cursor` to use `nextPage` in all functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for cc3bd9d84bc90b099a5382c623c58f36c86b8149. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->