### PR TITLE
chore(oauth): adding raw field to oauth response

### DIFF
--- a/connectors/cnext/_defaults/oauth2/def.ts
+++ b/connectors/cnext/_defaults/oauth2/def.ts
@@ -18,6 +18,9 @@ const zOAuthConnectionSettings = z.object({
       expires_at: z.string(),
       client_id: z.string(),
       token_type: z.string(),
+      // the data returned by the oauth provider in its raw form, currently used to parse the credentials object
+      // useful to access domain specific fields such as authed_user in slack https://api.slack.com/methods/oauth.v2.access#examples
+      raw: z.record(z.unknown()),
     })
     .optional()
     .describe('Output of the postConnect hook for oauth2 connectors'),

--- a/connectors/cnext/_defaults/oauth2/def.ts
+++ b/connectors/cnext/_defaults/oauth2/def.ts
@@ -13,11 +13,12 @@ const zOAuthConnectionSettings = z.object({
   credentials: z
     .object({
       access_token: z.string(),
-      refresh_token: z.string().optional(),
-      expires_in: z.number(),
-      expires_at: z.string(),
       client_id: z.string(),
-      token_type: z.string(),
+      scope: z.string(),
+      refresh_token: z.string().optional(),
+      expires_in: z.number().optional(),
+      expires_at: z.string().optional(),
+      token_type: z.string().optional(),
       // the data returned by the oauth provider in its raw form, currently used to parse the credentials object
       // useful to access domain specific fields such as authed_user in slack https://api.slack.com/methods/oauth.v2.access#examples
       raw: z.record(z.unknown()),

--- a/connectors/cnext/_defaults/oauth2/handlers.spec.ts
+++ b/connectors/cnext/_defaults/oauth2/handlers.spec.ts
@@ -1,0 +1,181 @@
+import {makeTokenRequest} from './handlers'
+
+// Mock fetch
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+describe('OAuth2 handlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('makeTokenRequest', () => {
+    test('should correctly handle token exchange with custom parameters', async () => {
+      // Mock successful token response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'test-access-token',
+          refresh_token: 'test-refresh-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          custom_field: 'custom-value',
+          scope: 'read write',
+        }),
+      })
+
+      // Parameters with custom fields
+      const params = {
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+        code: 'test-code',
+        redirect_uri: 'http://localhost/callback',
+        grant_type: 'authorization_code',
+        custom_param: 'custom-param-value',
+      }
+
+      // Call the makeTokenRequest function
+      const result = await makeTokenRequest(
+        'https://example.com/oauth/token',
+        params,
+        'exchange',
+      )
+
+      // Verify the fetch call includes all parameters
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const fetchCall = mockFetch.mock.calls[0]
+      expect(fetchCall[0]).toBe('https://example.com/oauth/token')
+
+      const fetchOptions = fetchCall[1]
+      expect(fetchOptions.method).toBe('POST')
+      expect(fetchOptions.headers).toEqual({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      })
+
+      const bodyParams = new URLSearchParams(fetchOptions.body)
+      expect(bodyParams.get('client_id')).toBe('test-client-id')
+      expect(bodyParams.get('client_secret')).toBe('test-client-secret')
+      expect(bodyParams.get('code')).toBe('test-code')
+      expect(bodyParams.get('redirect_uri')).toBe('http://localhost/callback')
+      expect(bodyParams.get('grant_type')).toBe('authorization_code')
+      expect(bodyParams.get('custom_param')).toBe('custom-param-value')
+
+      // Verify the result contains the parsed tokens
+      expect(result).toMatchObject({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        client_id: 'test-client-id',
+        scope: 'read write',
+        token_type: 'bearer',
+        expires_at: expect.any(String),
+        raw: {
+          access_token: 'test-access-token',
+          refresh_token: 'test-refresh-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          custom_field: 'custom-value',
+        },
+      })
+    })
+
+    test('should handle token refresh', async () => {
+      // Mock successful token response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          scope: 'read write',
+          expires_in: 7200,
+          token_type: 'bearer',
+        }),
+      })
+
+      // Parameters for refresh
+      const params = {
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+        refresh_token: 'old-refresh-token',
+        grant_type: 'refresh_token',
+      }
+
+      // Call the makeTokenRequest function
+      const result = await makeTokenRequest(
+        'https://example.com/oauth/token',
+        params,
+        'refresh',
+      )
+
+      // Verify the fetch call
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Verify the result
+      expect(result).toMatchObject({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        client_id: 'test-client-id',
+        token_type: 'bearer',
+        expires_at: expect.any(String),
+      })
+    })
+
+    test('should handle token request errors', async () => {
+      // Mock error response
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: async () =>
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Invalid authorization code',
+          }),
+      })
+
+      // Parameters
+      const params = {
+        client_id: 'error-client-id',
+        client_secret: 'error-client-secret',
+        code: 'invalid-code',
+        redirect_uri: 'http://localhost/callback',
+        grant_type: 'authorization_code',
+      }
+
+      // Call the makeTokenRequest function and expect it to throw
+      await expect(
+        makeTokenRequest('https://example.com/oauth/token', params, 'exchange'),
+      ).rejects.toThrow('Token exchange failed: 400 Bad Request')
+    })
+
+    test('should handle invalid response format', async () => {
+      // Mock successful response but with invalid format
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          expires_in: 3600,
+          // Missing required fields like access_token
+          some_other_field: 'value',
+        }),
+      })
+
+      // Parameters
+      const params = {
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+        code: 'test-code',
+        redirect_uri: 'http://localhost/callback',
+        grant_type: 'authorization_code',
+      }
+
+      // Call the makeTokenRequest function and expect it to throw
+      await expect(
+        makeTokenRequest('https://example.com/oauth/token', params, 'exchange'),
+      ).rejects.toThrow('Invalid oauth2 exchange token response format')
+    })
+  })
+})

--- a/connectors/cnext/_defaults/oauth2/handlers.ts
+++ b/connectors/cnext/_defaults/oauth2/handlers.ts
@@ -2,7 +2,7 @@ import {z} from 'zod'
 import {oauth2Schemas, zOAuthConfig} from './def'
 import {mapOauthParams, prepareScopes} from './utils'
 
-async function makeTokenRequest(
+export async function makeTokenRequest(
   url: string,
   params: Record<string, string>,
   flowType: 'exchange' | 'refresh',
@@ -32,9 +32,12 @@ async function makeTokenRequest(
       {
         ...json,
         client_id: params['client_id'],
-        token_type: json.token_type?.toLowerCase() ?? 'bearer',
         scope: json.scope ?? params['scope'],
-        expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
+        token_type: json.token_type?.toLowerCase(),
+        expires_at:
+          json.expires_in && json.expires_in > 0
+            ? new Date(Date.now() + json.expires_in * 1000).toISOString()
+            : undefined,
         raw: json,
       },
     )

--- a/connectors/cnext/_defaults/oauth2/handlers.ts
+++ b/connectors/cnext/_defaults/oauth2/handlers.ts
@@ -35,6 +35,7 @@ async function makeTokenRequest(
         token_type: json.token_type?.toLowerCase() ?? 'bearer',
         scope: json.scope ?? params['scope'],
         expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
+        raw: json,
       },
     )
   } catch (error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `raw` field to OAuth response and update `makeTokenRequest` to include it, with tests for various scenarios.
> 
>   - **Behavior**:
>     - Add `raw` field to OAuth response in `zOAuthConnectionSettings` in `def.ts` to store raw data from OAuth provider.
>     - Update `makeTokenRequest` in `handlers.ts` to include `raw` field in returned credentials.
>   - **Tests**:
>     - Add `handlers.spec.ts` to test `makeTokenRequest` for token exchange, refresh, error handling, and invalid response formats.
>   - **Misc**:
>     - Export `makeTokenRequest` in `handlers.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for c7fd78bc1e92c795f7d739160d0f68ea7c8bcf9f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->