### PR TITLE
optionally stripping oauth sensitive fields

### DIFF
--- a/packages/api-v1/routers/connection.spec.ts
+++ b/packages/api-v1/routers/connection.spec.ts
@@ -113,7 +113,11 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
     })
 
     // Via trpc
-    const conns = await asCustomer.caller.listConnections()
+
+    const conns = await asCustomer.caller.listConnections({
+      // TODO: @openint-bot, add tests for include_secrets cases
+      include_secrets: 'all',
+    })
     expect(conns.items).toHaveLength(1)
     expect(conns.items[0]).toMatchObject({
       id: connIdRef.current,

--- a/packages/api-v1/routers/connection.ts
+++ b/packages/api-v1/routers/connection.ts
@@ -6,7 +6,7 @@ import {and, eq, schema, sql} from '@openint/db'
 import {core} from '../models'
 import {orgProcedure, publicProcedure, router} from '../trpc/_base'
 import {type RouterContext} from '../trpc/context'
-import {expandConnector, zExpandOptions} from './connectorConfig'
+import {expandConnector} from './connectorConfig'
 import {
   applyPaginationAndOrder,
   processPaginatedResponse,
@@ -41,6 +41,14 @@ const zConnectionError = z
   .enum(['refresh_failed', 'unknown_external_error'])
   .describe('Error types: refresh_failed and unknown_external_error')
 
+function stripSensitiveOauthCredentials(credentials: any) {
+  return {
+    ...credentials,
+    refresh_token: undefined,
+    raw: undefined,
+  }
+}
+
 async function formatConnection(
   ctx: RouterContext,
   connection: z.infer<typeof core.connection>,
@@ -62,9 +70,16 @@ async function formatConnection(
     settingsToInclude = {
       settings: {
         ...connection.settings,
-        oauth: {
-          credentials: connection.settings.oauth.credentials,
-        },
+        // NOTE: in future we should add other settings sensitive value
+        // stripping for things like api key here and abstract it
+        oauth: connection.settings?.oauth?.credentials
+          ? {
+              ...connection.settings.oauth,
+              credentials: stripSensitiveOauthCredentials(
+                connection.settings.oauth.credentials,
+              ),
+            }
+          : undefined,
       },
     }
   } else if (include_secrets === 'all') {
@@ -95,6 +110,19 @@ async function formatConnection(
   }
 }
 
+const connectionWithRelations = z
+  .intersection(
+    core.connection,
+    z.object({
+      connector: core.connector.optional(),
+    }),
+  )
+  .describe('The connection details')
+
+const zExpandOptions = z
+  .enum(['connector'])
+  .describe('Fields to expand: connector (includes connector details)')
+
 export const connectionRouter = router({
   getConnection: publicProcedure
     .meta({
@@ -114,7 +142,7 @@ export const connectionRouter = router({
         expand: z.array(zExpandOptions).optional().default([]),
       }),
     )
-    .output(core.connection.describe('The connection details'))
+    .output(connectionWithRelations)
     .query(async ({ctx, input}) => {
       console.log(
         'getConnection',
@@ -230,7 +258,11 @@ export const connectionRouter = router({
         })
         .optional(),
     )
-    .output(zListResponse(core.connection).describe('The list of connections'))
+    .output(
+      zListResponse(connectionWithRelations).describe(
+        'The list of connections',
+      ),
+    )
     .query(async ({ctx, input}) => {
       // Create a query that selects all fields from connection and adds a window function for the count
       const {query, limit, offset} = applyPaginationAndOrder(

--- a/packages/api-v1/routers/connection.ts
+++ b/packages/api-v1/routers/connection.ts
@@ -65,7 +65,8 @@ async function formatConnection(
   }
 
   // Handle different levels of secret inclusion
-  let settingsToInclude = {}
+  // the default is 'none' at which point settings should be an empty object
+  let settingsToInclude = {settings: {}}
   if (include_secrets === 'basic' && connection.settings.oauth) {
     settingsToInclude = {
       settings: {
@@ -144,13 +145,13 @@ export const connectionRouter = router({
     )
     .output(connectionWithRelations)
     .query(async ({ctx, input}) => {
-      console.log(
-        'getConnection',
-        input.id,
-        input.include_secrets,
-        input.refresh_policy,
-        input.expand,
-      )
+      // console.log(
+      //   'getConnection',
+      //   input.id,
+      //   input.include_secrets,
+      //   input.refresh_policy,
+      //   input.expand,
+      // )
       let connection = await ctx.db.query.connection.findFirst({
         where: eq(schema.connection.id, input.id),
       })

--- a/packages/api-v1/routers/connectorConfig.ts
+++ b/packages/api-v1/routers/connectorConfig.ts
@@ -23,7 +23,7 @@ const validateResponse = (res: Array<Core['connector_config']>, id: string) => {
   }
 }
 
-export const zExpandOptions = z
+const zExpandOptions = z
   .enum(['connector', 'enabled_integrations', 'connection_count'])
   .describe(
     'Fields to expand: connector (includes connector details), enabled_integrations (includes enabled integrations details)',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add optional stripping of sensitive OAuth fields in connection settings with tests for secret inclusion levels.
> 
>   - **Behavior**:
>     - Add `stripSensitiveOauthCredentials` function in `connection.ts` to remove `refresh_token` and `raw` fields from OAuth credentials.
>     - Modify `formatConnection` in `connection.ts` to handle `include_secrets` parameter with levels: `none`, `basic`, `all`.
>     - Update `listConnections` and `getConnection` in `connection.ts` to use `connectionWithRelations` schema.
>   - **Tests**:
>     - Update `connection.spec.ts` to test `include_secrets: 'all'` case in `listConnections`.
>   - **Misc**:
>     - Remove unused import `zExpandOptions` from `connection.ts` and `connectorConfig.ts`.
>     - Comment out console logs in `getConnection` query in `connection.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 957bade3c5ecdfee86dbd93a7dec049b54f71fb9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->