### PR TITLE
Update expand connector to comma separated string, address feedback from ccfg pr, minor cleanups

### DIFF
--- a/apps/web/app/(v1)/console/(authenticated)/connections/client.tsx
+++ b/apps/web/app/(v1)/console/(authenticated)/connections/client.tsx
@@ -2,7 +2,7 @@
 
 import {Loader2, Trash} from 'lucide-react'
 import {useMemo} from 'react'
-import {Core} from '@openint/api-v1/models'
+import type {Core} from '@openint/api-v1/models'
 import {Button} from '@openint/shadcn/ui'
 import {
   AlertDialog,
@@ -19,7 +19,7 @@ import {DataTable, type ColumnDef} from '@openint/ui-v1/components/DataTable'
 import {useMutation, useSuspenseQuery} from '@openint/ui-v1/trpc'
 import {useTRPC} from '../client'
 
-const columns: ColumnDef<Core['connection']>[] = [
+const columns: Array<ColumnDef<Core['connection']>> = [
   {
     id: 'id',
     header: 'id',
@@ -66,8 +66,8 @@ export function ConnectionList(props: {
 
   const deleteConn = useMutation(
     trpc.deleteConnection.mutationOptions({
-      onSuccess: () => {
-        connectionData.refetch()
+      onSuccess: async () => {
+        await connectionData.refetch()
       },
       onError: (error) => {
         // TODO: @rodri77 - Add a toast to the UI.
@@ -82,51 +82,51 @@ export function ConnectionList(props: {
       {
         id: 'actions',
         header: 'Actions',
-        cell: ({row}) => {
-          return (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="ghost" size="icon">
-                  <Trash className="size-6 text-red-500" />
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete Connection</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Are you sure you want to delete this connection? This action
-                    cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel disabled={deleteConn.isPending}>
-                    Cancel
-                  </AlertDialogCancel>
-                  <AlertDialogAction
-                    disabled={deleteConn.isPending}
-                    onClick={() => deleteConn.mutate({id: row.original.id})}>
-                    {deleteConn.isPending ? (
-                      <>
-                        <Loader2 className="mr-2 size-4 animate-spin" />
-                        Deleting...
-                      </>
-                    ) : (
-                      'Delete'
-                    )}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-                {deleteConn.isPending && (
-                  <div className="bg-background/80 absolute inset-0 flex items-center justify-center">
-                    <Loader2 className="size-8 animate-spin" />
-                  </div>
-                )}
-              </AlertDialogContent>
-            </AlertDialog>
-          )
-        },
+        cell: ({row}) => (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="ghost" size="icon">
+                <Trash className="size-6 text-red-500" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete Connection</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to delete this connection? This action
+                  cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={deleteConn.isPending}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  disabled={deleteConn.isPending}
+                  onClick={() => {
+                    deleteConn.mutate({id: row.original.id})
+                  }}>
+                  {deleteConn.isPending ? (
+                    <>
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                      Deleting...
+                    </>
+                  ) : (
+                    'Delete'
+                  )}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+              {deleteConn.isPending && (
+                <div className="bg-background/80 absolute inset-0 flex items-center justify-center">
+                  <Loader2 className="size-8 animate-spin" />
+                </div>
+              )}
+            </AlertDialogContent>
+          </AlertDialog>
+        ),
       } as ColumnDef<Core['connection']>,
     ],
-    [columns, deleteConn],
+    [deleteConn],
   )
 
   return (

--- a/packages/api-v1/routers/connection.spec.ts
+++ b/packages/api-v1/routers/connection.spec.ts
@@ -140,7 +140,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
       id: connIdRef.current,
     })
 
-    expect(res).toEqual(connIdRef.current)
+    expect(res).toEqual({id: connIdRef.current})
   })
 
   test('delete connection with invalid id returns error', async () => {

--- a/packages/api-v1/routers/connection.ts
+++ b/packages/api-v1/routers/connection.ts
@@ -405,7 +405,7 @@ export const connectionRouter = router({
       },
     })
     .input(z.object({id: zConnectionId}))
-    .output(zConnectionId)
+    .output(z.object({id: zConnectionId}))
     .mutation(async ({ctx, input}) => {
       const connection = await ctx.db.query.connection.findFirst({
         where: eq(schema.connection.id, input.id),
@@ -420,6 +420,6 @@ export const connectionRouter = router({
       await ctx.db
         .delete(schema.connection)
         .where(eq(schema.connection.id, input.id))
-      return input.id
+      return {id: connection.id}
     }),
 })

--- a/packages/api-v1/routers/connector.spec.ts
+++ b/packages/api-v1/routers/connector.spec.ts
@@ -21,7 +21,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
   })
 
   test('list connectors with integrations', async () => {
-    const res = await asOrg.listConnectors({expand: ['integrations']})
+    const res = await asOrg.listConnectors({expand: 'integrations'})
     const mergeIndex = res.findIndex((c) => c.name === 'merge')
 
     expect(res[mergeIndex]?.integrations?.length).toBeGreaterThan(1)

--- a/packages/api-v1/routers/connector.ts
+++ b/packages/api-v1/routers/connector.ts
@@ -50,7 +50,7 @@ export const connectorRouter = router({
         .object({
           expand: z
             .string()
-            .transform((val) => val.split(','))
+            .transform((val) => val.split(',').map(s => s.trim()))
             .refine(
               (items) =>
                 items.every((item) => zExpandOptions.safeParse(item).success),

--- a/packages/api-v1/routers/connector.ts
+++ b/packages/api-v1/routers/connector.ts
@@ -29,6 +29,8 @@ export const zExpandOptions = z
   .enum(['integrations'])
   .describe('Fields to expand connector with its integrations')
 
+type ExpandEnum = z.infer<typeof zExpandOptions>
+
 const zConnectorName = z.enum(
   Object.keys(defConnectors) as [string, ...string[]],
 )
@@ -46,7 +48,21 @@ export const connectorRouter = router({
     .input(
       z
         .object({
-          expand: z.array(zExpandOptions).optional().default([]),
+          expand: z
+            .string()
+            .transform((val) => val.split(','))
+            .refine(
+              (items) =>
+                items.every((item) => zExpandOptions.safeParse(item).success),
+              {
+                message:
+                  'Invalid expand option. Valid options are: integrations',
+              },
+            )
+            .describe(
+              'Comma separated list of fields to optionally expand.\n\nAvailable Options: `integrations`',
+            )
+            .optional(),
         })
         .optional(),
     )
@@ -65,9 +81,11 @@ export const connectorRouter = router({
             },
           )
 
+          const expand = (input?.expand || []) as ExpandEnum[]
+
           const server = serverConnectors[name as keyof typeof serverConnectors]
           if (
-            input?.expand.includes('integrations') &&
+            expand.includes('integrations') &&
             server &&
             'listIntegrations' in server
           ) {

--- a/packages/api-v1/routers/connectorConfig.spec.ts
+++ b/packages/api-v1/routers/connectorConfig.spec.ts
@@ -240,7 +240,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
       id,
     })
     expect(res).toBeDefined()
-    expect(res).toEqual(id)
+    expect(res).toEqual({id})
   })
 
   test('delete connector with invalid id returns error', async () => {

--- a/packages/api-v1/routers/connectorConfig.ts
+++ b/packages/api-v1/routers/connectorConfig.ts
@@ -4,7 +4,7 @@ import {defConnectors} from '@openint/all-connectors/connectors.def'
 import {makeId} from '@openint/cdk'
 import {and, eq, schema, sql} from '@openint/db'
 import {makeUlid} from '@openint/util'
-import {Core, core} from '../models'
+import {core, type Core} from '../models'
 import {authenticatedProcedure, orgProcedure, router} from '../trpc/_base'
 import {
   applyPaginationAndOrder,
@@ -12,7 +12,7 @@ import {
   zListParams,
   zListResponse,
 } from './utils/pagination'
-import {zConnectorName} from './utils/types'
+import {zConnectorConfigId, zConnectorName} from './utils/types'
 
 const validateResponse = (res: Array<Core['connector_config']>, id: string) => {
   if (!res.length) {
@@ -286,7 +286,7 @@ export const connectorConfigRouter = router({
     })
     .input(
       z.object({
-        id: z.string(),
+        id: zConnectorConfigId,
         display_name: z.string().optional(),
         disabled: z.boolean().optional(),
         config: z.record(z.unknown()).nullish(),
@@ -334,8 +334,8 @@ export const connectorConfigRouter = router({
         enabled: false,
       },
     })
-    .input(z.object({id: z.string()}))
-    .output(z.string())
+    .input(z.object({id: zConnectorConfigId}))
+    .output(z.object({id: zConnectorConfigId}))
     .mutation(async ({ctx, input}) => {
       const {id} = input
 
@@ -356,6 +356,6 @@ export const connectorConfigRouter = router({
         .delete(schema.connector_config)
         .where(eq(schema.connector_config.id, id))
 
-      return id
+      return {id}
     }),
 })

--- a/packages/api-v1/trpc/openapi-to-trpc.spec.ts
+++ b/packages/api-v1/trpc/openapi-to-trpc.spec.ts
@@ -47,7 +47,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
     app = createApp({db})
   })
 
-  test('GET /connector-config with expand options array', async () => {
+  test('GET /connector-config with expand options', async () => {
     const headers = new Headers()
     headers.set('authorization', `Bearer ${testApiKey}`)
     headers.set('accept', 'application/json')
@@ -96,6 +96,47 @@ describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
     expect(response.status).toBe(400)
     expect(result.issues[0].message).toEqual(
       'Invalid expand option. Valid options are: connector, enabled_integrations, connection_count',
+    )
+  })
+
+  test('GET /connector with expand options', async () => {
+    const headers = new Headers()
+    headers.set('authorization', `Bearer ${testApiKey}`)
+    headers.set('accept', 'application/json')
+
+    const url = new URL('http://localhost/api/v1/connector')
+    url.searchParams.set('expand', 'integrations')
+
+    const req = new Request(url, {headers})
+
+    const response = await app.handle(req)
+    const result = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(result).toBeTruthy()
+    expect(result.length).toBeGreaterThan(0)
+
+    const googleConnector = result.find((item: any) => item.name === 'google')
+    expect(googleConnector).toBeDefined()
+    expect(googleConnector.integrations).toBeDefined()
+  })
+
+  test('GET /connector with invalid expand options', async () => {
+    const headers = new Headers()
+    headers.set('authorization', `Bearer ${testApiKey}`)
+    headers.set('accept', 'application/json')
+
+    const url = new URL('http://localhost/api/v1/connector')
+    url.searchParams.set('expand', 'foo')
+
+    const req = new Request(url, {headers})
+
+    const response = await app.handle(req)
+    const result = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(result.issues[0].message).toEqual(
+      'Invalid expand option. Valid options are: integrations',
     )
   })
 })

--- a/packages/ui-v1/components/schema-form/SchemaForm.tsx
+++ b/packages/ui-v1/components/schema-form/SchemaForm.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type {
   default as Form,
   FormProps,


### PR DESCRIPTION
Addressed feedback from [Ccfg sheet PR](https://github.com/openintegrations/openint/pull/378)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update expand connector to use comma-separated strings and refine connection handling.
> 
>   - **Behavior**:
>     - Update `listConnectors` and `listConnectorConfigs` to use comma-separated strings for `expand` options in `connector.ts` and `connectorConfig.ts`.
>     - Modify `deleteConnection` to return an object with `id` in `connection.ts`.
>   - **Tests**:
>     - Update tests in `connection.spec.ts`, `connector.spec.ts`, `connectorConfig.spec.ts`, and `openapi-to-trpc.spec.ts` to reflect changes in `expand` handling and `deleteConnection` response.
>   - **Type Changes**:
>     - Change `columns` type from `ColumnDef<Core['connection']>[]` to `Array<ColumnDef<Core['connection']>>` in `client.tsx`.
>     - Use `type` keyword for imports in `client.tsx` and `connectorConfig.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 9c3eb2d0242f6573e18b9e3ff79f115f7d60335f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->