### PR TITLE
fix(v1): adding /api/v1 url

### DIFF
--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Run type checks
         run: pnpm run typecheck
 
-
   lint:
     runs-on: ubuntu-latest
     needs: install-dependencies
@@ -120,7 +119,7 @@ jobs:
       - name: Download environment variables
         run: |
           npm install --global vercel@latest
-          vercel link --token $VERCEL_TOKEN --scope openint-dev --yes
+          vercel link --token $VERCEL_TOKEN --scope openint-dev --project v1 --yes
           vercel env pull --token $VERCEL_TOKEN ./apps/web/.env.local.orig
           cat ./apps/web/.env.local.orig | pnpm --silent bun scripts/escape-env.ts > ./apps/web/.env.local
       - name: Run migrations
@@ -165,7 +164,7 @@ jobs:
       - name: Download environment variables
         run: |
           npm install --global vercel@latest
-          vercel link --token $VERCEL_TOKEN --scope openint-dev --yes
+          vercel link --token $VERCEL_TOKEN --scope openint-dev --project v1 --yes
           vercel env pull --token $VERCEL_TOKEN ./apps/web/.env.local.orig
           cat ./apps/web/.env.local.orig | pnpm --silent bun scripts/escape-env.ts > ./apps/web/.env.local
 

--- a/apps/web/app/api/[[...api]]/route.ts
+++ b/apps/web/app/api/[[...api]]/route.ts
@@ -1,20 +1,12 @@
+import {modifyRequest} from '@opensdks/fetch-links'
 import {createApp} from '@openint/api-v1'
 import {db} from '@/lib-server/globals'
 
 const app = createApp({db})
-const handler = (req: Request) => {
-  if (req.url.includes('/v1') && !req.url.includes('/api/v1')) {
-    const cleanUrl = req.url.replace('/v1', '/api/v1')
-    return app.handle(
-      new Request(cleanUrl, {
-        method: req.method,
-        headers: req.headers,
-        body: req.body,
-      }),
-    )
-  }
-  return app.handle(req)
-}
+
+/** Elysia will assume that it is the root route, so we need to modify the url to correspond to it */
+const handler = (req: Request) =>
+  app.handle(modifyRequest(req, {url: req.url.replace(/^\/api/i, '')}))
 
 export {
   handler as DELETE,

--- a/apps/web/app/api/[[...api]]/route.ts
+++ b/apps/web/app/api/[[...api]]/route.ts
@@ -2,8 +2,13 @@ import {createApp} from '@openint/api-v1'
 import {db} from '@/lib-server/globals'
 
 const app = createApp({db})
-
-const handler = app.handle
+const handler = (req: Request) => {
+  if (req.url.includes('/v1') && !req.url.includes('/api/v1')) {
+    const cleanUrl = req.url.replace('/v1', '/api/v1')
+    return app.handle(new Request(cleanUrl, req))
+  }
+  return app.handle(req)
+}
 
 export {
   handler as DELETE,

--- a/apps/web/app/api/[[...api]]/route.ts
+++ b/apps/web/app/api/[[...api]]/route.ts
@@ -5,7 +5,13 @@ const app = createApp({db})
 const handler = (req: Request) => {
   if (req.url.includes('/v1') && !req.url.includes('/api/v1')) {
     const cleanUrl = req.url.replace('/v1', '/api/v1')
-    return app.handle(new Request(cleanUrl, req))
+    return app.handle(
+      new Request(cleanUrl, {
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+      }),
+    )
   }
   return app.handle(req)
 }

--- a/apps/web/app/api/[[...api]]/route.ts
+++ b/apps/web/app/api/[[...api]]/route.ts
@@ -5,8 +5,11 @@ import {db} from '@/lib-server/globals'
 const app = createApp({db})
 
 /** Elysia will assume that it is the root route, so we need to modify the url to correspond to it */
-const handler = (req: Request) =>
-  app.handle(modifyRequest(req, {url: req.url.replace(/^\/api/i, '')}))
+const handler = (req: Request) => {
+  const url = new URL(req.url)
+  url.pathname = url.pathname.replace(/^\/api/i, '')
+  return app.handle(modifyRequest(req, {url: url.toString()}))
+}
 
 export {
   handler as DELETE,

--- a/packages/api-v1/__tests__/app.spec.ts
+++ b/packages/api-v1/__tests__/app.spec.ts
@@ -21,20 +21,20 @@ afterAll(async () => {
 
 describe('elysia', () => {
   test('GET /health', async () => {
-    const res = await app.handle(new Request('http://localhost/api/health'))
+    const res = await app.handle(new Request('http://localhost/health'))
     expect(await res.json()).toBeTruthy()
   })
 
   test('GET /health with loopback link', async () => {
     const handler = (req: Request) =>
       applyLinks(req, [loopbackLink(), app.handle])
-    const res = await handler(new Request('http://localhost/api/health'))
+    const res = await handler(new Request('http://localhost/health'))
     expect(await res.json()).toBeTruthy()
   })
 
   test('POST /health', async () => {
     const res = await app.handle(
-      new Request('http://localhost/api/health', {
+      new Request('http://localhost/health', {
         method: 'POST',
         body: JSON.stringify({foo: 'bar'}),
         headers: {'Content-Type': 'application/json'},
@@ -47,13 +47,13 @@ describe('elysia', () => {
 
 describe('openapi route', () => {
   test('GET /health', async () => {
-    const res = await app.handle(new Request('http://localhost/api/v1/health'))
+    const res = await app.handle(new Request('http://localhost/v1/health'))
     expect(await res.json()).toMatchObject({ok: true})
   })
 
   test('POST /health', async () => {
     const res = await app.handle(
-      new Request('http://localhost/api/v1/health', {
+      new Request('http://localhost/v1/health', {
         method: 'POST',
         body: JSON.stringify({foo: 'bar'}),
         headers: {'Content-Type': 'application/json'},
@@ -64,15 +64,15 @@ describe('openapi route', () => {
   })
 
   test('healthcheck bypass elysia', async () => {
-    const handler = createFetchHandlerOpenAPI({endpoint: '/api/v1', db})
-    const res = await handler(new Request('http://localhost/api/v1/health'))
+    const handler = createFetchHandlerOpenAPI({endpoint: '/v1', db})
+    const res = await handler(new Request('http://localhost/v1/health'))
     expect(await res.json()).toMatchObject({ok: true})
   })
 
   test('POST healthcheck bypass elysia', async () => {
-    const handler = createFetchHandlerOpenAPI({endpoint: '/api/v1', db})
+    const handler = createFetchHandlerOpenAPI({endpoint: '/v1', db})
     const res = await handler(
-      new Request('http://localhost/api/v1/health', {
+      new Request('http://localhost/v1/health', {
         method: 'POST',
         body: JSON.stringify({foo: 'bar'}),
         headers: {'Content-Type': 'application/json'},
@@ -85,7 +85,7 @@ describe('openapi route', () => {
   // openapi.json to avoid confusion in the documentation
   test('with OpenAPI client', async () => {
     const openapiClient = createClient<paths>({
-      baseUrl: 'http://localhost/api/v1',
+      baseUrl: 'http://localhost/v1',
       fetch: app.handle,
     })
 
@@ -99,7 +99,7 @@ describe('openapi route', () => {
 
   test('with OpenAPI client with links', async () => {
     const openapiClient = createClient<paths>({
-      baseUrl: 'http://localhost/api/v1',
+      baseUrl: 'http://localhost/v1',
       fetch: (req) => applyLinks(req, [logLink(), app.handle]),
     })
     const res = await openapiClient.GET('/health')
@@ -110,14 +110,14 @@ describe('openapi route', () => {
 describe('trpc route', () => {
   test('query health', async () => {
     const res = await app.handle(
-      new Request('http://localhost/api/v1/trpc/health'),
+      new Request('http://localhost/v1/trpc/health'),
     )
     expect(await res.json()).toMatchObject({result: {data: {ok: true}}})
   })
 
   test('mutation health', async () => {
     const res = await app.handle(
-      new Request('http://localhost/api/v1/trpc/healthEcho', {
+      new Request('http://localhost/v1/trpc/healthEcho', {
         method: 'POST',
         body: JSON.stringify({foo: 'bar'}),
         headers: {'Content-Type': 'application/json'},
@@ -129,9 +129,9 @@ describe('trpc route', () => {
   })
 
   test('query health bypass elysia', async () => {
-    const handler = createFetchHandlerTRPC({endpoint: '/api/v1/trpc', db})
+    const handler = createFetchHandlerTRPC({endpoint: '/v1/trpc', db})
     const res = await handler(
-      new Request('http://localhost/api/v1/trpc/health'),
+      new Request('http://localhost/v1/trpc/health'),
     )
     expect(await res.json()).toMatchObject({result: {data: {ok: true}}})
   })
@@ -140,7 +140,7 @@ describe('trpc route', () => {
     const client = createTRPCClient<AppRouter>({
       links: [
         httpLink({
-          url: 'http://localhost/api/v1/trpc',
+          url: 'http://localhost/v1/trpc',
           fetch: (input, init) => app.handle(new Request(input, init)),
         }),
       ],

--- a/packages/api-v1/__tests__/test-utils.ts
+++ b/packages/api-v1/__tests__/test-utils.ts
@@ -20,13 +20,13 @@ export function getTestTRPCClient(
   viewerOrKey: Viewer | {api_key: string},
 ) {
   const handler = router
-    ? createFetchHandlerTRPC({...opts, router, endpoint: '/api/v1/trpc'})
+    ? createFetchHandlerTRPC({...opts, router, endpoint: '/v1/trpc'})
     : createApp(opts).handle
 
   return createTRPCClient<AppRouter>({
     links: [
       httpLink({
-        url: 'http://localhost/api/v1/trpc',
+        url: 'http://localhost/v1/trpc',
         fetch: (input, init) => handler(new Request(input, init)),
         headers:
           'api_key' in viewerOrKey

--- a/packages/api-v1/app.ts
+++ b/packages/api-v1/app.ts
@@ -14,13 +14,13 @@ export interface CreateAppOptions
 
 // It's annoying how elysia does not really allow for dependency injection like TRPC, so we do ourselves
 export function createApp({db}: CreateAppOptions) {
-  const app = new Elysia({prefix: '/api'})
+  const app = new Elysia()
     .get('/health', () => ({healthy: true}))
     .post('/health', (ctx) => ({healthy: true, body: ctx.body}))
     .use(
       swagger({
         // For some reason spec.content doesn't work. so we are forced tos specify url instead
-        scalarConfig: {spec: {url: '/api/v1/openapi.json'}},
+        scalarConfig: {spec: {url: '/v1/openapi.json'}},
         path: '/v1',
       }),
     )
@@ -30,10 +30,10 @@ export function createApp({db}: CreateAppOptions) {
     // no other settings seems to work when mounted inside next.js. Direct elysia listen works
     // in a more consistent way and we should probably add some test specifically for next.js mounted behavior
     .all('/v1/trpc/*', ({request}) =>
-      createFetchHandlerTRPC({endpoint: '/api/v1/trpc', db})(request),
+      createFetchHandlerTRPC({endpoint: '/v1/trpc', db})(request),
     )
     .all('/v1/*', ({request}) =>
-      createFetchHandlerOpenAPI({endpoint: '/api/v1', db})(request),
+      createFetchHandlerOpenAPI({endpoint: '/v1', db})(request),
     )
   return app
 }

--- a/packages/api-v1/routers/general.ts
+++ b/packages/api-v1/routers/general.ts
@@ -35,7 +35,6 @@ export const generalRouter = router({
     .output(z.object({role: z.enum(['customer', 'org', 'anon', 'user'])}))
     // @ts-expect-error
     .query(({ctx}) => {
-      console.log('ctx', ctx)
       return {role: ctx.viewer.role}
     }),
 })

--- a/packages/api-v1/trpc/openapi-to-trpc.spec.ts
+++ b/packages/api-v1/trpc/openapi-to-trpc.spec.ts
@@ -8,6 +8,9 @@ import {createApp} from '../app'
 const testApiKey = `apikey_${makeUlid()}`
 const testOrgId = `org_${makeUlid()}` as Id['org']
 
+
+
+
 describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
   let app: ReturnType<typeof createApp>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removed `/api` prefix from API endpoints and updated tests and workflows to reflect this change.
> 
>   - **API Endpoint Changes**:
>     - Removed `/api` prefix from API endpoints in `route.ts`.
>     - Updated endpoint paths in `app.ts` to remove `/api` prefix.
>   - **Test Updates**:
>     - Modified test requests in `app.spec.ts` and `openapi-to-trpc.spec.ts` to reflect new endpoint paths without `/api`.
>     - Updated `test-utils.ts` to use new endpoint paths.
>   - **Workflow Changes**:
>     - Updated `parallel-workflow-validate.yml` to specify `--project v1` for Vercel linking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 9876bc66e7cdd851aac3c8b5a7ab1e5cef91bc99. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->