### PR TITLE
fix(docs): hiding private apis and improving summaries

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -188,10 +188,12 @@ jobs:
           pnpm gen:docs-oas
           cd ..
 
-      - name: Update production branch
+      - name: Update main & production branches
+        env:
+          GH_TOKEN: ${{ secrets.AP_GH_PAT }}
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.name "Amadeo Pellicce (Automated PR)"
+          git config user.email "pellicceama@gmail.com"
           git fetch 
 
           # Add all generated files
@@ -218,7 +220,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         with:
-          deployment-url: openint-git-main-openint-dev.vercel.app # TODO Replace by the domain you want to test
+          deployment-url: v1-git-main-openint-dev.vercel.app # TODO Replace by the domain you want to test
           timeout: 10 # Wait for 10 seconds before failing
           poll-interval: 1 # Wait for 1 second before each retry
 

--- a/docs/generateDocsOas.bin.cjs
+++ b/docs/generateDocsOas.bin.cjs
@@ -57,7 +57,7 @@ async function main() {
   const oas = await getOasSpec()
 
   // no longer in use
-  const pathsToFilterOut = []
+  const pathsToFilterOut = ['/health']
 
   const filteredPaths = Object.keys(oas.paths)
     .filter((path) => !pathsToFilterOut.includes(path))

--- a/docs/generateDocsOas.bin.cjs
+++ b/docs/generateDocsOas.bin.cjs
@@ -57,7 +57,7 @@ async function main() {
   const oas = await getOasSpec()
 
   // no longer in use
-  const pathsToFilterOut = ['/health']
+  const pathsToFilterOut = ['/health', '/viewer']
 
   const filteredPaths = Object.keys(oas.paths)
     .filter((path) => !pathsToFilterOut.includes(path))

--- a/docs/generateDocsOas.bin.cjs
+++ b/docs/generateDocsOas.bin.cjs
@@ -3,51 +3,53 @@ const https = require('https')
 const yaml = require('js-yaml')
 
 async function getOasSpec() {
-  if (process.env.NODE_ENV === 'development') {
-    const {exec} = require('child_process')
-
-    // Run the pnpm gen command in the api-v1 package
-    exec('pnpm gen', {cwd: '../packages/api-v1'}, (error, stdout, stderr) => {
-      if (error) {
-        console.error(`Error executing pnpm gen: ${error.message}`)
-        return
-      }
-      if (stderr) {
-        console.error(`pnpm gen stderr: ${stderr}`)
-        return
-      }
-      return JSON.parse(
-        fs.readFileSync(
-          '../packages/api-v1/__generated__/openapi.json',
-          'utf8',
-        ),
-      )
-    })
-  }
-
   return new Promise((resolve, reject) => {
-    https.get(
-      'https://app.stainless.com/api/spec/documented/openint',
-      (res) => {
-        let data = ''
+    if (process.env.NODE_ENV === 'development') {
+      const {exec} = require('child_process')
 
-        res.on('data', (chunk) => {
-          data += chunk
-        })
+      // Run the pnpm gen command in the api-v1 package
+      exec('pnpm gen', {cwd: '../packages/api-v1'}, (error, stdout, stderr) => {
+        if (error) {
+          console.error(`Error executing pnpm gen: ${error.message}`)
+          reject(new Error('pnpm gen stderr'))
+        }
+        if (stderr) {
+          console.error(`pnpm gen stderr: ${stderr}`)
+          reject(new Error('pnpm gen stderr'))
+        }
+        resolve(
+          JSON.parse(
+            fs.readFileSync(
+              '../packages/api-v1/__generated__/openapi.json',
+              'utf8',
+            ),
+          ),
+        )
+      })
+    } else {
+      https.get(
+        'https://app.stainless.com/api/spec/documented/openint',
+        (res) => {
+          let data = ''
 
-        res.on('end', () => {
-          try {
-            resolve(yaml.load(data))
-          } catch (e) {
-            reject(e)
-          }
-        })
+          res.on('data', (chunk) => {
+            data += chunk
+          })
 
-        res.on('error', (err) => {
-          reject(err)
-        })
-      },
-    )
+          res.on('end', () => {
+            try {
+              resolve(yaml.load(data))
+            } catch (e) {
+              reject(e)
+            }
+          })
+
+          res.on('error', (err) => {
+            reject(err)
+          })
+        },
+      )
+    }
   })
 }
 

--- a/docs/mintlify.oas.yml
+++ b/docs/mintlify.oas.yml
@@ -8,8 +8,8 @@ paths:
   /connector:
     get:
       operationId: listConnectors
-      summary: List all connectors
-      description: List all connectors with optional filtering
+      summary: List Connectors
+      description: List all connectors to understand what integrations are available to configure
       security:
         - ApiKey: []
         - CustomerToken: []
@@ -392,34 +392,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              // Automatically fetches more pages as needed.
-              for await (const listConnectionConfigsResponse of client.listConnectionConfigs()) {
-                console.log(listConnectionConfigsResponse);
-              }
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            page = client.list_connection_configs()
-            page = page.items[0]
-            print(page)
   /connection/{id}:
     get:
       operationId: getConnection
@@ -664,36 +636,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              const response = await client.getConnection('conn_');
-
-              console.log(response);
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            response = client.get_connection(
-                id="conn_",
-            )
-            print(response)
     delete:
       operationId: deleteConnection
+      summary: Delete Connection
+      description: Delete a connection
       security:
         - ApiKey: []
         - CustomerToken: []
@@ -1093,36 +1039,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              // Automatically fetches more pages as needed.
-              for await (const listConnectionsResponse of client.listConnections()) {
-                console.log(listConnectionsResponse);
-              }
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            page = client.list_connections()
-            page = page.items[0]
-            print(page)
     post:
       operationId: createConnection
+      summary: Create Connection
       description: Import an existing connection after validation
       security:
         - ApiKey: []
@@ -1374,343 +1293,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              const response = await client.checkConnection('conn_');
-
-              console.log(response.id);
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            response = client.check_connection(
-                "conn_",
-            )
-            print(response.id)
-  /connect/pre-connect:
-    post:
-      operationId: preConnect
-      security:
-        - ApiKey: []
-        - CustomerToken: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  description: |-
-                    Must correspond to data.connector_name.
-                    Technically id should imply connector_name already but there is no way to
-                    specify a discriminated union with id alone.
-                options:
-                  type: object
-                  properties:
-                    integrationExternalId:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: 'null'
-                    connectionExternalId:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: 'null'
-                data:
-                  oneOf:
-                    - $ref: '#/components/schemas/connectors.aircall.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.airtable.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.apollo.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.brex.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.coda.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.confluence.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.discord.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.facebook.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.finch.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.firebase.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.foreceipt.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.github.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.gong.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.googlecalendar.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.googledocs.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.googledrive.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.googlemail.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.googlesheet.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.greenhouse.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.heron.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.hubspot.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.instagram.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.intercom.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.jira.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.kustomer.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.lever.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.linear.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.linkedin.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.lunchmoney.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.mercury.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.merge.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.microsoft.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.moota.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.notion.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.onebrick.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.outreach.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.pipedrive.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.plaid.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.postgres.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.quickbooks.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.ramp.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.reddit.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.salesforce.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.salesloft.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.saltedge.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.sharepointonline.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.slack.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.splitwise.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.stripe.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.teller.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.toggl.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.twenty.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.twitter.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.venmo.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.wise.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.xero.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.yodlee.preConnectInput'
-                    - $ref: '#/components/schemas/connectors.zohodesk.preConnectInput'
-                  discriminator:
-                    propertyName: connector_name
-                    mapping:
-                      aircall: '#/components/schemas/connectors.aircall.preConnectInput'
-                      airtable: '#/components/schemas/connectors.airtable.preConnectInput'
-                      apollo: '#/components/schemas/connectors.apollo.preConnectInput'
-                      brex: '#/components/schemas/connectors.brex.preConnectInput'
-                      coda: '#/components/schemas/connectors.coda.preConnectInput'
-                      confluence: '#/components/schemas/connectors.confluence.preConnectInput'
-                      discord: '#/components/schemas/connectors.discord.preConnectInput'
-                      facebook: '#/components/schemas/connectors.facebook.preConnectInput'
-                      finch: '#/components/schemas/connectors.finch.preConnectInput'
-                      firebase: '#/components/schemas/connectors.firebase.preConnectInput'
-                      foreceipt: '#/components/schemas/connectors.foreceipt.preConnectInput'
-                      github: '#/components/schemas/connectors.github.preConnectInput'
-                      gong: '#/components/schemas/connectors.gong.preConnectInput'
-                      googlecalendar: '#/components/schemas/connectors.googlecalendar.preConnectInput'
-                      googledocs: '#/components/schemas/connectors.googledocs.preConnectInput'
-                      googledrive: '#/components/schemas/connectors.googledrive.preConnectInput'
-                      googlemail: '#/components/schemas/connectors.googlemail.preConnectInput'
-                      googlesheet: '#/components/schemas/connectors.googlesheet.preConnectInput'
-                      greenhouse: '#/components/schemas/connectors.greenhouse.preConnectInput'
-                      heron: '#/components/schemas/connectors.heron.preConnectInput'
-                      hubspot: '#/components/schemas/connectors.hubspot.preConnectInput'
-                      instagram: '#/components/schemas/connectors.instagram.preConnectInput'
-                      intercom: '#/components/schemas/connectors.intercom.preConnectInput'
-                      jira: '#/components/schemas/connectors.jira.preConnectInput'
-                      kustomer: '#/components/schemas/connectors.kustomer.preConnectInput'
-                      lever: '#/components/schemas/connectors.lever.preConnectInput'
-                      linear: '#/components/schemas/connectors.linear.preConnectInput'
-                      linkedin: '#/components/schemas/connectors.linkedin.preConnectInput'
-                      lunchmoney: '#/components/schemas/connectors.lunchmoney.preConnectInput'
-                      mercury: '#/components/schemas/connectors.mercury.preConnectInput'
-                      merge: '#/components/schemas/connectors.merge.preConnectInput'
-                      microsoft: '#/components/schemas/connectors.microsoft.preConnectInput'
-                      moota: '#/components/schemas/connectors.moota.preConnectInput'
-                      notion: '#/components/schemas/connectors.notion.preConnectInput'
-                      onebrick: '#/components/schemas/connectors.onebrick.preConnectInput'
-                      outreach: '#/components/schemas/connectors.outreach.preConnectInput'
-                      pipedrive: '#/components/schemas/connectors.pipedrive.preConnectInput'
-                      plaid: '#/components/schemas/connectors.plaid.preConnectInput'
-                      postgres: '#/components/schemas/connectors.postgres.preConnectInput'
-                      quickbooks: '#/components/schemas/connectors.quickbooks.preConnectInput'
-                      ramp: '#/components/schemas/connectors.ramp.preConnectInput'
-                      reddit: '#/components/schemas/connectors.reddit.preConnectInput'
-                      salesforce: '#/components/schemas/connectors.salesforce.preConnectInput'
-                      salesloft: '#/components/schemas/connectors.salesloft.preConnectInput'
-                      saltedge: '#/components/schemas/connectors.saltedge.preConnectInput'
-                      sharepointonline: '#/components/schemas/connectors.sharepointonline.preConnectInput'
-                      slack: '#/components/schemas/connectors.slack.preConnectInput'
-                      splitwise: '#/components/schemas/connectors.splitwise.preConnectInput'
-                      stripe: '#/components/schemas/connectors.stripe.preConnectInput'
-                      teller: '#/components/schemas/connectors.teller.preConnectInput'
-                      toggl: '#/components/schemas/connectors.toggl.preConnectInput'
-                      twenty: '#/components/schemas/connectors.twenty.preConnectInput'
-                      twitter: '#/components/schemas/connectors.twitter.preConnectInput'
-                      venmo: '#/components/schemas/connectors.venmo.preConnectInput'
-                      wise: '#/components/schemas/connectors.wise.preConnectInput'
-                      xero: '#/components/schemas/connectors.xero.preConnectInput'
-                      yodlee: '#/components/schemas/connectors.yodlee.preConnectInput'
-                      zohodesk: '#/components/schemas/connectors.zohodesk.preConnectInput'
-                  description: Connector specific data
-              required:
-                - id
-                - options
-                - data
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/connectors.aircall.connectInput'
-                  - $ref: '#/components/schemas/connectors.airtable.connectInput'
-                  - $ref: '#/components/schemas/connectors.apollo.connectInput'
-                  - $ref: '#/components/schemas/connectors.brex.connectInput'
-                  - $ref: '#/components/schemas/connectors.coda.connectInput'
-                  - $ref: '#/components/schemas/connectors.confluence.connectInput'
-                  - $ref: '#/components/schemas/connectors.discord.connectInput'
-                  - $ref: '#/components/schemas/connectors.facebook.connectInput'
-                  - $ref: '#/components/schemas/connectors.finch.connectInput'
-                  - $ref: '#/components/schemas/connectors.firebase.connectInput'
-                  - $ref: '#/components/schemas/connectors.foreceipt.connectInput'
-                  - $ref: '#/components/schemas/connectors.github.connectInput'
-                  - $ref: '#/components/schemas/connectors.gong.connectInput'
-                  - $ref: '#/components/schemas/connectors.googlecalendar.connectInput'
-                  - $ref: '#/components/schemas/connectors.googledocs.connectInput'
-                  - $ref: '#/components/schemas/connectors.googledrive.connectInput'
-                  - $ref: '#/components/schemas/connectors.googlemail.connectInput'
-                  - $ref: '#/components/schemas/connectors.googlesheet.connectInput'
-                  - $ref: '#/components/schemas/connectors.greenhouse.connectInput'
-                  - $ref: '#/components/schemas/connectors.heron.connectInput'
-                  - $ref: '#/components/schemas/connectors.hubspot.connectInput'
-                  - $ref: '#/components/schemas/connectors.instagram.connectInput'
-                  - $ref: '#/components/schemas/connectors.intercom.connectInput'
-                  - $ref: '#/components/schemas/connectors.jira.connectInput'
-                  - $ref: '#/components/schemas/connectors.kustomer.connectInput'
-                  - $ref: '#/components/schemas/connectors.lever.connectInput'
-                  - $ref: '#/components/schemas/connectors.linear.connectInput'
-                  - $ref: '#/components/schemas/connectors.linkedin.connectInput'
-                  - $ref: '#/components/schemas/connectors.lunchmoney.connectInput'
-                  - $ref: '#/components/schemas/connectors.mercury.connectInput'
-                  - $ref: '#/components/schemas/connectors.merge.connectInput'
-                  - $ref: '#/components/schemas/connectors.microsoft.connectInput'
-                  - $ref: '#/components/schemas/connectors.moota.connectInput'
-                  - $ref: '#/components/schemas/connectors.notion.connectInput'
-                  - $ref: '#/components/schemas/connectors.onebrick.connectInput'
-                  - $ref: '#/components/schemas/connectors.outreach.connectInput'
-                  - $ref: '#/components/schemas/connectors.pipedrive.connectInput'
-                  - $ref: '#/components/schemas/connectors.plaid.connectInput'
-                  - $ref: '#/components/schemas/connectors.postgres.connectInput'
-                  - $ref: '#/components/schemas/connectors.quickbooks.connectInput'
-                  - $ref: '#/components/schemas/connectors.ramp.connectInput'
-                  - $ref: '#/components/schemas/connectors.reddit.connectInput'
-                  - $ref: '#/components/schemas/connectors.salesforce.connectInput'
-                  - $ref: '#/components/schemas/connectors.salesloft.connectInput'
-                  - $ref: '#/components/schemas/connectors.saltedge.connectInput'
-                  - $ref: '#/components/schemas/connectors.sharepointonline.connectInput'
-                  - $ref: '#/components/schemas/connectors.slack.connectInput'
-                  - $ref: '#/components/schemas/connectors.splitwise.connectInput'
-                  - $ref: '#/components/schemas/connectors.stripe.connectInput'
-                  - $ref: '#/components/schemas/connectors.teller.connectInput'
-                  - $ref: '#/components/schemas/connectors.toggl.connectInput'
-                  - $ref: '#/components/schemas/connectors.twenty.connectInput'
-                  - $ref: '#/components/schemas/connectors.twitter.connectInput'
-                  - $ref: '#/components/schemas/connectors.venmo.connectInput'
-                  - $ref: '#/components/schemas/connectors.wise.connectInput'
-                  - $ref: '#/components/schemas/connectors.xero.connectInput'
-                  - $ref: '#/components/schemas/connectors.yodlee.connectInput'
-                  - $ref: '#/components/schemas/connectors.zohodesk.connectInput'
-                discriminator:
-                  propertyName: connector_name
-                  mapping:
-                    aircall: '#/components/schemas/connectors.aircall.connectInput'
-                    airtable: '#/components/schemas/connectors.airtable.connectInput'
-                    apollo: '#/components/schemas/connectors.apollo.connectInput'
-                    brex: '#/components/schemas/connectors.brex.connectInput'
-                    coda: '#/components/schemas/connectors.coda.connectInput'
-                    confluence: '#/components/schemas/connectors.confluence.connectInput'
-                    discord: '#/components/schemas/connectors.discord.connectInput'
-                    facebook: '#/components/schemas/connectors.facebook.connectInput'
-                    finch: '#/components/schemas/connectors.finch.connectInput'
-                    firebase: '#/components/schemas/connectors.firebase.connectInput'
-                    foreceipt: '#/components/schemas/connectors.foreceipt.connectInput'
-                    github: '#/components/schemas/connectors.github.connectInput'
-                    gong: '#/components/schemas/connectors.gong.connectInput'
-                    googlecalendar: '#/components/schemas/connectors.googlecalendar.connectInput'
-                    googledocs: '#/components/schemas/connectors.googledocs.connectInput'
-                    googledrive: '#/components/schemas/connectors.googledrive.connectInput'
-                    googlemail: '#/components/schemas/connectors.googlemail.connectInput'
-                    googlesheet: '#/components/schemas/connectors.googlesheet.connectInput'
-                    greenhouse: '#/components/schemas/connectors.greenhouse.connectInput'
-                    heron: '#/components/schemas/connectors.heron.connectInput'
-                    hubspot: '#/components/schemas/connectors.hubspot.connectInput'
-                    instagram: '#/components/schemas/connectors.instagram.connectInput'
-                    intercom: '#/components/schemas/connectors.intercom.connectInput'
-                    jira: '#/components/schemas/connectors.jira.connectInput'
-                    kustomer: '#/components/schemas/connectors.kustomer.connectInput'
-                    lever: '#/components/schemas/connectors.lever.connectInput'
-                    linear: '#/components/schemas/connectors.linear.connectInput'
-                    linkedin: '#/components/schemas/connectors.linkedin.connectInput'
-                    lunchmoney: '#/components/schemas/connectors.lunchmoney.connectInput'
-                    mercury: '#/components/schemas/connectors.mercury.connectInput'
-                    merge: '#/components/schemas/connectors.merge.connectInput'
-                    microsoft: '#/components/schemas/connectors.microsoft.connectInput'
-                    moota: '#/components/schemas/connectors.moota.connectInput'
-                    notion: '#/components/schemas/connectors.notion.connectInput'
-                    onebrick: '#/components/schemas/connectors.onebrick.connectInput'
-                    outreach: '#/components/schemas/connectors.outreach.connectInput'
-                    pipedrive: '#/components/schemas/connectors.pipedrive.connectInput'
-                    plaid: '#/components/schemas/connectors.plaid.connectInput'
-                    postgres: '#/components/schemas/connectors.postgres.connectInput'
-                    quickbooks: '#/components/schemas/connectors.quickbooks.connectInput'
-                    ramp: '#/components/schemas/connectors.ramp.connectInput'
-                    reddit: '#/components/schemas/connectors.reddit.connectInput'
-                    salesforce: '#/components/schemas/connectors.salesforce.connectInput'
-                    salesloft: '#/components/schemas/connectors.salesloft.connectInput'
-                    saltedge: '#/components/schemas/connectors.saltedge.connectInput'
-                    sharepointonline: '#/components/schemas/connectors.sharepointonline.connectInput'
-                    slack: '#/components/schemas/connectors.slack.connectInput'
-                    splitwise: '#/components/schemas/connectors.splitwise.connectInput'
-                    stripe: '#/components/schemas/connectors.stripe.connectInput'
-                    teller: '#/components/schemas/connectors.teller.connectInput'
-                    toggl: '#/components/schemas/connectors.toggl.connectInput'
-                    twenty: '#/components/schemas/connectors.twenty.connectInput'
-                    twitter: '#/components/schemas/connectors.twitter.connectInput'
-                    venmo: '#/components/schemas/connectors.venmo.connectInput'
-                    wise: '#/components/schemas/connectors.wise.connectInput'
-                    xero: '#/components/schemas/connectors.xero.connectInput'
-                    yodlee: '#/components/schemas/connectors.yodlee.connectInput'
-                    zohodesk: '#/components/schemas/connectors.zohodesk.connectInput'
-                description: Connector specific data
-        '400':
-          description: Invalid input data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.BAD_REQUEST'
-        '401':
-          description: Authorization not provided
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.UNAUTHORIZED'
-        '403':
-          description: Insufficient access
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.FORBIDDEN'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
   /customer/{customer_id}/magic-link:
     post:
       operationId: createMagicLink
@@ -1861,34 +1443,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              const response = await client.createMagicLink('customer_id');
-
-              console.log(response.magic_link_url);
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            response = client.create_magic_link(
-                customer_id="customer_id",
-            )
-            print(response.magic_link_url)
   /customer/{customer_id}/token:
     post:
       operationId: createToken
@@ -1954,279 +1508,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              const response = await client.createToken('customer_id');
-
-              console.log(response.token);
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            response = client.create_token(
-                customer_id="customer_id",
-            )
-            print(response.token)
-  /customers:
-    get:
-      operationId: listCustomers
-      summary: List Customers
-      description: List all customers
-      security:
-        - ApiKey: []
-        - CustomerToken: []
-      parameters:
-        - in: query
-          name: limit
-          description: Limit the number of items returned
-          schema:
-            type: integer
-            minimum: 0
-            maximum: 100
-            default: 50
-            description: Limit the number of items returned
-        - in: query
-          name: offset
-          description: Offset the items returned
-          schema:
-            type: integer
-            minimum: 0
-            default: 0
-            description: Offset the items returned
-        - in: query
-          name: keywords
-          schema:
-            type:
-              - string
-              - 'null'
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/core.customer'
-                  total:
-                    type: integer
-                    minimum: 0
-                    description: Total number of items in the database for the organization
-                  limit:
-                    type: integer
-                    minimum: 0
-                    maximum: 100
-                    default: 50
-                    description: Limit the number of items returned
-                  offset:
-                    type: integer
-                    minimum: 0
-                    default: 0
-                    description: Offset the items returned
-                required:
-                  - items
-                  - total
-                  - limit
-                  - offset
-        '400':
-          description: Invalid input data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.BAD_REQUEST'
-        '401':
-          description: Authorization not provided
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.UNAUTHORIZED'
-        '403':
-          description: Insufficient access
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.FORBIDDEN'
-        '404':
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.NOT_FOUND'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-  /health:
-    get:
-      operationId: health
-      summary: Health Check
-      description: Check if the API is operational
-      security:
-        - ApiKey: []
-        - CustomerToken: []
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                required:
-                  - ok
-        '401':
-          description: Authorization not provided
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.UNAUTHORIZED'
-        '403':
-          description: Insufficient access
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.FORBIDDEN'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-    post:
-      operationId: healthEcho
-      security:
-        - ApiKey: []
-        - CustomerToken: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-        '400':
-          description: Invalid input data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.BAD_REQUEST'
-        '401':
-          description: Authorization not provided
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.UNAUTHORIZED'
-        '403':
-          description: Insufficient access
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.FORBIDDEN'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-  /viewer:
-    get:
-      operationId: viewer
-      summary: Get Current User
-      description: Get information about the current authenticated user
-      security:
-        - ApiKey: []
-        - CustomerToken: []
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  role:
-                    type: string
-                    enum:
-                      - customer
-                      - org
-                      - anon
-                      - user
-                required:
-                  - role
-        '401':
-          description: Authorization not provided
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.UNAUTHORIZED'
-        '403':
-          description: Insufficient access
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.FORBIDDEN'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error.INTERNAL_SERVER_ERROR'
-      x-codeSamples:
-        - lang: JavaScript
-          source: |-
-            import Openint from '@openint/sdk';
-
-            const client = new Openint({
-              apiKey: process.env['OPENINT_API_KEY'], // This is the default and can be omitted
-            });
-
-            async function main() {
-              const response = await client.getCurrentUser();
-
-              console.log(response.role);
-            }
-
-            main();
-        - lang: Python
-          source: |-
-            import os
-            from openint import Openint
-
-            client = Openint(
-                api_key=os.environ.get("OPENINT_API_KEY"),  # This is the default and can be omitted
-            )
-            response = client.get_current_user()
-            print(response.role)
 components:
   securitySchemes:
     ApiKey:
@@ -2247,23 +1528,6 @@ components:
         - BASIC
         - API_KEY
       title: AuthMode
-    connectors.aircall.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: aircall
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: aircall
     connectors.aircall.connectionSettings:
       type: object
       properties:
@@ -2359,30 +1623,6 @@ components:
         - connector_name
         - config
       title: aircall
-    connectors.aircall.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: aircall
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: aircall
-    connectors.airtable.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: airtable
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: airtable
     connectors.airtable.connectionSettings:
       type: object
       properties:
@@ -2415,30 +1655,6 @@ components:
         - connector_name
         - config
       title: airtable
-    connectors.airtable.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: airtable
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: airtable
-    connectors.apollo.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: apollo
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: apollo
     connectors.apollo.connectionSettings:
       type: object
       properties:
@@ -2554,30 +1770,6 @@ components:
         - connector_name
         - config
       title: apollo
-    connectors.apollo.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: apollo
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: apollo
-    connectors.brex.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: brex
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: brex
     connectors.brex.connectionSettings:
       type: object
       properties:
@@ -2626,30 +1818,6 @@ components:
         - connector_name
         - config
       title: brex
-    connectors.brex.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: brex
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: brex
-    connectors.coda.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: coda
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: coda
     connectors.coda.connectionSettings:
       type: object
       properties:
@@ -2679,35 +1847,6 @@ components:
         - connector_name
         - config
       title: coda
-    connectors.coda.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: coda
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: coda
-    connectors.confluence.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: confluence
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: confluence
     connectors.confluence.connectionSettings:
       type: object
       properties:
@@ -2803,35 +1942,6 @@ components:
         - connector_name
         - config
       title: confluence
-    connectors.confluence.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: confluence
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: confluence
-    connectors.discord.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: discord
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: discord
     connectors.discord.connectionSettings:
       type: object
       properties:
@@ -2927,30 +2037,6 @@ components:
         - connector_name
         - config
       title: discord
-    connectors.discord.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: discord
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: discord
-    connectors.facebook.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: facebook
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: facebook
     connectors.facebook.connectionSettings:
       type: object
       properties:
@@ -3081,49 +2167,6 @@ components:
         - connector_name
         - config
       title: facebook
-    connectors.facebook.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: facebook
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: facebook
-    connectors.finch.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: finch
-        output:
-          type: object
-          properties:
-            client_id:
-              type: string
-            products:
-              type: array
-              items:
-                type: string
-                enum:
-                  - company
-                  - directory
-                  - individual
-                  - ssn
-                  - employment
-                  - payment
-                  - pay_statement
-                  - benefits
-          required:
-            - client_id
-            - products
-      required:
-        - connector_name
-        - output
-      title: finch
     connectors.finch.connectionSettings:
       type: object
       properties:
@@ -3179,33 +2222,6 @@ components:
         - connector_name
         - config
       title: finch
-    connectors.finch.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: finch
-        input:
-          type: object
-          properties:
-            state:
-              type: string
-      required:
-        - connector_name
-        - input
-      title: finch
-    connectors.firebase.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: firebase
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: firebase
     connectors.firebase.connectionSettings:
       type: object
       properties:
@@ -3328,40 +2344,6 @@ components:
         - connector_name
         - config
       title: firebase
-    connectors.firebase.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: firebase
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: firebase
-    connectors.foreceipt.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: foreceipt
-        output:
-          type: object
-          properties:
-            credentials: {}
-            _id: {}
-            envName:
-              type: string
-              enum:
-                - staging
-                - production
-          required:
-            - envName
-      required:
-        - connector_name
-        - output
-      title: foreceipt
     connectors.foreceipt.connectionSettings:
       type: object
       properties:
@@ -3396,35 +2378,6 @@ components:
         - connector_name
         - config
       title: foreceipt
-    connectors.foreceipt.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: foreceipt
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: foreceipt
-    connectors.github.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: github
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: github
     connectors.github.connectionSettings:
       type: object
       properties:
@@ -3520,30 +2473,6 @@ components:
         - connector_name
         - config
       title: github
-    connectors.github.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: github
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: github
-    connectors.gong.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: gong
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: gong
     connectors.gong.connectionSettings:
       type: object
       properties:
@@ -3674,35 +2603,6 @@ components:
         - connector_name
         - config
       title: gong
-    connectors.gong.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: gong
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: gong
-    connectors.googlecalendar.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googlecalendar
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: googlecalendar
     connectors.googlecalendar.connectionSettings:
       type: object
       properties:
@@ -3798,35 +2698,6 @@ components:
         - connector_name
         - config
       title: googlecalendar
-    connectors.googlecalendar.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googlecalendar
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: googlecalendar
-    connectors.googledocs.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googledocs
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: googledocs
     connectors.googledocs.connectionSettings:
       type: object
       properties:
@@ -3922,35 +2793,6 @@ components:
         - connector_name
         - config
       title: googledocs
-    connectors.googledocs.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googledocs
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: googledocs
-    connectors.googledrive.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googledrive
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: googledrive
     connectors.googledrive.connectionSettings:
       type: object
       properties:
@@ -4046,35 +2888,6 @@ components:
         - connector_name
         - config
       title: googledrive
-    connectors.googledrive.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googledrive
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: googledrive
-    connectors.googlemail.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googlemail
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: googlemail
     connectors.googlemail.connectionSettings:
       type: object
       properties:
@@ -4170,35 +2983,6 @@ components:
         - connector_name
         - config
       title: googlemail
-    connectors.googlemail.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googlemail
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: googlemail
-    connectors.googlesheet.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googlesheet
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: googlesheet
     connectors.googlesheet.connectionSettings:
       type: object
       properties:
@@ -4294,28 +3078,6 @@ components:
         - connector_name
         - config
       title: googlesheet
-    connectors.googlesheet.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: googlesheet
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: googlesheet
-    connectors.greenhouse.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: greenhouse
-        output: {}
-      required:
-        - connector_name
-      title: greenhouse
     connectors.greenhouse.connectionSettings:
       type: object
       properties:
@@ -4345,28 +3107,6 @@ components:
         - connector_name
         - config
       title: greenhouse
-    connectors.greenhouse.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: greenhouse
-        input: {}
-      required:
-        - connector_name
-      title: greenhouse
-    connectors.heron.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: heron
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: heron
     connectors.heron.connectionSettings:
       type: object
       properties:
@@ -4396,35 +3136,6 @@ components:
         - connector_name
         - config
       title: heron
-    connectors.heron.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: heron
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: heron
-    connectors.hubspot.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: hubspot
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: hubspot
     connectors.hubspot.connectionSettings:
       type: object
       properties:
@@ -4520,30 +3231,6 @@ components:
         - connector_name
         - config
       title: hubspot
-    connectors.hubspot.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: hubspot
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: hubspot
-    connectors.instagram.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: instagram
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: instagram
     connectors.instagram.connectionSettings:
       type: object
       properties:
@@ -4674,30 +3361,6 @@ components:
         - connector_name
         - config
       title: instagram
-    connectors.instagram.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: instagram
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: instagram
-    connectors.intercom.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: intercom
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: intercom
     connectors.intercom.connectionSettings:
       type: object
       properties:
@@ -4828,30 +3491,6 @@ components:
         - connector_name
         - config
       title: intercom
-    connectors.intercom.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: intercom
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: intercom
-    connectors.jira.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: jira
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: jira
     connectors.jira.connectionSettings:
       type: object
       properties:
@@ -4982,30 +3621,6 @@ components:
         - connector_name
         - config
       title: jira
-    connectors.jira.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: jira
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: jira
-    connectors.kustomer.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: kustomer
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: kustomer
     connectors.kustomer.connectionSettings:
       type: object
       properties:
@@ -5136,30 +3751,6 @@ components:
         - connector_name
         - config
       title: kustomer
-    connectors.kustomer.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: kustomer
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: kustomer
-    connectors.lever.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: lever
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: lever
     connectors.lever.connectionSettings:
       type: object
       properties:
@@ -5296,35 +3887,6 @@ components:
         - connector_name
         - config
       title: lever
-    connectors.lever.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: lever
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: lever
-    connectors.linear.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: linear
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: linear
     connectors.linear.connectionSettings:
       type: object
       properties:
@@ -5420,35 +3982,6 @@ components:
         - connector_name
         - config
       title: linear
-    connectors.linear.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: linear
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: linear
-    connectors.linkedin.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: linkedin
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: linkedin
     connectors.linkedin.connectionSettings:
       type: object
       properties:
@@ -5544,30 +4077,6 @@ components:
         - connector_name
         - config
       title: linkedin
-    connectors.linkedin.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: linkedin
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: linkedin
-    connectors.lunchmoney.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: lunchmoney
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: lunchmoney
     connectors.lunchmoney.connectionSettings:
       type: object
       properties:
@@ -5597,30 +4106,6 @@ components:
         - connector_name
         - config
       title: lunchmoney
-    connectors.lunchmoney.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: lunchmoney
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: lunchmoney
-    connectors.mercury.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: mercury
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: mercury
     connectors.mercury.connectionSettings:
       type: object
       properties:
@@ -5664,35 +4149,6 @@ components:
         - connector_name
         - config
       title: mercury
-    connectors.mercury.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: mercury
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: mercury
-    connectors.merge.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: merge
-        output:
-          type: object
-          properties:
-            link_token:
-              type: string
-          required:
-            - link_token
-      required:
-        - connector_name
-        - output
-      title: merge
     connectors.merge.connectionSettings:
       type: object
       properties:
@@ -5728,40 +4184,6 @@ components:
         - connector_name
         - config
       title: merge
-    connectors.merge.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: merge
-        input:
-          type: object
-          properties:
-            categories:
-              type: array
-              items: {}
-            customer_email_address:
-              type: string
-            customer_organization_name:
-              type: string
-          required:
-            - categories
-      required:
-        - connector_name
-        - input
-      title: merge
-    connectors.microsoft.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: microsoft
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: microsoft
     connectors.microsoft.connectionSettings:
       type: object
       properties:
@@ -5923,30 +4345,6 @@ components:
         - connector_name
         - config
       title: microsoft
-    connectors.microsoft.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: microsoft
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: microsoft
-    connectors.moota.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: moota
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: moota
     connectors.moota.connectionSettings:
       type: object
       properties:
@@ -5976,35 +4374,6 @@ components:
         - connector_name
         - config
       title: moota
-    connectors.moota.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: moota
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: moota
-    connectors.notion.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: notion
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: notion
     connectors.notion.connectionSettings:
       type: object
       properties:
@@ -6100,39 +4469,6 @@ components:
         - connector_name
         - config
       title: notion
-    connectors.notion.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: notion
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: notion
-    connectors.onebrick.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: onebrick
-        output:
-          type: object
-          properties:
-            publicToken:
-              type:
-                - string
-                - 'null'
-            redirect_url:
-              type:
-                - string
-                - 'null'
-      required:
-        - connector_name
-        - output
-      title: onebrick
     connectors.onebrick.connectionSettings:
       type: object
       properties:
@@ -6187,30 +4523,6 @@ components:
         - connector_name
         - config
       title: onebrick
-    connectors.onebrick.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: onebrick
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: onebrick
-    connectors.outreach.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: outreach
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: outreach
     connectors.outreach.connectionSettings:
       type: object
       properties:
@@ -6341,30 +4653,6 @@ components:
         - connector_name
         - config
       title: outreach
-    connectors.outreach.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: outreach
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: outreach
-    connectors.pipedrive.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: pipedrive
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: pipedrive
     connectors.pipedrive.connectionSettings:
       type: object
       properties:
@@ -6495,42 +4783,6 @@ components:
         - connector_name
         - config
       title: pipedrive
-    connectors.pipedrive.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: pipedrive
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: pipedrive
-    connectors.plaid.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: plaid
-        output:
-          anyOf:
-            - type: object
-              properties:
-                link_token:
-                  type: string
-              required:
-                - link_token
-            - type: object
-              properties:
-                public_token:
-                  type: string
-              required:
-                - public_token
-      required:
-        - connector_name
-        - output
-      title: plaid
     connectors.plaid.connectionSettings:
       type: object
       properties:
@@ -6661,41 +4913,6 @@ components:
         - connector_name
         - config
       title: plaid
-    connectors.plaid.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: plaid
-        input:
-          type: object
-          properties:
-            sandboxPublicTokenCreate:
-              type: boolean
-            language:
-              type: string
-              enum:
-                - en
-                - fr
-                - es
-                - nl
-                - de
-      required:
-        - connector_name
-        - input
-      title: plaid
-    connectors.postgres.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: postgres
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: postgres
     connectors.postgres.connectionSettings:
       type: object
       properties:
@@ -6733,35 +4950,6 @@ components:
         - connector_name
         - config
       title: postgres
-    connectors.postgres.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: postgres
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: postgres
-    connectors.quickbooks.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: quickbooks
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: quickbooks
     connectors.quickbooks.connectionSettings:
       type: object
       properties:
@@ -6862,35 +5050,6 @@ components:
         - connector_name
         - config
       title: quickbooks
-    connectors.quickbooks.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: quickbooks
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: quickbooks
-    connectors.ramp.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: ramp
-        output:
-          type: object
-          properties:
-            accessToken:
-              type:
-                - string
-                - 'null'
-      required:
-        - connector_name
-        - output
-      title: ramp
     connectors.ramp.connectionSettings:
       type: object
       properties:
@@ -6937,30 +5096,6 @@ components:
         - connector_name
         - config
       title: ramp
-    connectors.ramp.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: ramp
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: ramp
-    connectors.reddit.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: reddit
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: reddit
     connectors.reddit.connectionSettings:
       type: object
       properties:
@@ -7091,35 +5226,6 @@ components:
         - connector_name
         - config
       title: reddit
-    connectors.reddit.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: reddit
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: reddit
-    connectors.salesforce.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: salesforce
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: salesforce
     connectors.salesforce.connectionSettings:
       type: object
       properties:
@@ -7220,30 +5326,6 @@ components:
         - connector_name
         - config
       title: salesforce
-    connectors.salesforce.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: salesforce
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: salesforce
-    connectors.salesloft.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: salesloft
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: salesloft
     connectors.salesloft.connectionSettings:
       type: object
       properties:
@@ -7374,30 +5456,6 @@ components:
         - connector_name
         - config
       title: salesloft
-    connectors.salesloft.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: salesloft
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: salesloft
-    connectors.saltedge.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: saltedge
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: saltedge
     connectors.saltedge.connectionSettings:
       type: object
       properties:
@@ -7432,35 +5490,6 @@ components:
         - connector_name
         - config
       title: saltedge
-    connectors.saltedge.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: saltedge
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: saltedge
-    connectors.sharepointonline.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: sharepointonline
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: sharepointonline
     connectors.sharepointonline.connectionSettings:
       type: object
       properties:
@@ -7556,35 +5585,6 @@ components:
         - connector_name
         - config
       title: sharepointonline
-    connectors.sharepointonline.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: sharepointonline
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: sharepointonline
-    connectors.slack.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: slack
-        output:
-          type: object
-          properties:
-            authorization_url:
-              type: string
-          required:
-            - authorization_url
-      required:
-        - connector_name
-        - output
-      title: slack
     connectors.slack.connectionSettings:
       type: object
       properties:
@@ -7680,30 +5680,6 @@ components:
         - connector_name
         - config
       title: slack
-    connectors.slack.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: slack
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: slack
-    connectors.splitwise.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: splitwise
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: splitwise
     connectors.splitwise.connectionSettings:
       type: object
       properties:
@@ -7838,30 +5814,6 @@ components:
         - connector_name
         - config
       title: splitwise
-    connectors.splitwise.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: splitwise
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: splitwise
-    connectors.stripe.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: stripe
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: stripe
     connectors.stripe.connectionSettings:
       type: object
       properties:
@@ -7910,39 +5862,6 @@ components:
         - connector_name
         - config
       title: stripe
-    connectors.stripe.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: stripe
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: stripe
-    connectors.teller.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: teller
-        output:
-          type: object
-          properties:
-            applicationId:
-              type: string
-            userToken:
-              type:
-                - string
-                - 'null'
-          required:
-            - applicationId
-      required:
-        - connector_name
-        - output
-      title: teller
     connectors.teller.connectionSettings:
       type: object
       properties:
@@ -7981,35 +5900,6 @@ components:
         - connector_name
         - config
       title: teller
-    connectors.teller.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: teller
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: teller
-    connectors.toggl.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: toggl
-        output:
-          type: object
-          properties:
-            apiToken:
-              type: string
-          required:
-            - apiToken
-      required:
-        - connector_name
-        - output
-      title: toggl
     connectors.toggl.connectionSettings:
       type: object
       properties:
@@ -8047,30 +5937,6 @@ components:
         - connector_name
         - config
       title: toggl
-    connectors.toggl.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: toggl
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: toggl
-    connectors.twenty.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: twenty
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: twenty
     connectors.twenty.connectionSettings:
       type: object
       properties:
@@ -8100,30 +5966,6 @@ components:
         - connector_name
         - config
       title: twenty
-    connectors.twenty.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: twenty
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: twenty
-    connectors.twitter.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: twitter
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: twitter
     connectors.twitter.connectionSettings:
       type: object
       properties:
@@ -8254,30 +6096,6 @@ components:
         - connector_name
         - config
       title: twitter
-    connectors.twitter.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: twitter
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: twitter
-    connectors.venmo.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: venmo
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: venmo
     connectors.venmo.connectionSettings:
       type: object
       properties:
@@ -8326,44 +6144,6 @@ components:
         - connector_name
         - config
       title: venmo
-    connectors.venmo.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: venmo
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: venmo
-    connectors.wise.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: wise
-        output:
-          type: object
-          properties:
-            redirectUri:
-              type: string
-            clientId:
-              type: string
-            envName:
-              type: string
-              enum:
-                - sandbox
-                - live
-          required:
-            - redirectUri
-            - clientId
-            - envName
-      required:
-        - connector_name
-        - output
-      title: wise
     connectors.wise.connectionSettings:
       type: object
       properties:
@@ -8400,30 +6180,6 @@ components:
         - connector_name
         - config
       title: wise
-    connectors.wise.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: wise
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: wise
-    connectors.xero.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: xero
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: xero
     connectors.xero.connectionSettings:
       type: object
       properties:
@@ -8554,53 +6310,6 @@ components:
         - connector_name
         - config
       title: xero
-    connectors.xero.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: xero
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: xero
-    connectors.yodlee.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: yodlee
-        output:
-          type: object
-          properties:
-            accessToken:
-              type: object
-              properties:
-                accessToken:
-                  type: string
-                issuedAt:
-                  type: string
-                expiresIn:
-                  type: number
-              required:
-                - accessToken
-                - issuedAt
-                - expiresIn
-            envName:
-              type: string
-              enum:
-                - sandbox
-                - development
-                - production
-          required:
-            - accessToken
-            - envName
-      required:
-        - connector_name
-        - output
-      title: yodlee
     connectors.yodlee.connectionSettings:
       type: object
       properties:
@@ -8727,30 +6436,6 @@ components:
         - connector_name
         - config
       title: yodlee
-    connectors.yodlee.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: yodlee
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
-      title: yodlee
-    connectors.zohodesk.connectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: zohodesk
-        output:
-          type: 'null'
-      required:
-        - connector_name
-        - output
-      title: zohodesk
     connectors.zohodesk.connectionSettings:
       type: object
       properties:
@@ -8880,18 +6565,6 @@ components:
       required:
         - connector_name
         - config
-      title: zohodesk
-    connectors.zohodesk.preConnectInput:
-      type: object
-      properties:
-        connector_name:
-          type: string
-          const: zohodesk
-        input:
-          type: 'null'
-      required:
-        - connector_name
-        - input
       title: zohodesk
     core.connection:
       allOf:
@@ -9088,23 +6761,6 @@ components:
       required:
         - name
       title: Connector
-    core.customer:
-      type: object
-      properties:
-        id:
-          type: string
-        updated_at:
-          type: string
-        created_at:
-          type: string
-        connection_count:
-          type: number
-      required:
-        - id
-        - updated_at
-        - created_at
-        - connection_count
-      title: Customer
     core.integration:
       type: object
       properties:

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -2596,6 +2596,77 @@
           }
         }
       }
+    },
+    "/viewer": {
+      "get": {
+        "operationId": "viewer",
+        "summary": "Get Current User",
+        "description": "Get information about the current authenticated user",
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "CustomerToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "role": {
+                      "type": "string",
+                      "enum": [
+                        "customer",
+                        "org",
+                        "anon",
+                        "user"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -13,8 +13,8 @@
     "/connector": {
       "get": {
         "operationId": "listConnectors",
-        "summary": "List all connectors",
-        "description": "List all connectors with optional filtering",
+        "summary": "List Connectors",
+        "description": "List all connectors to understand what integrations are available to configure",
         "security": [
           {
             "ApiKey": []
@@ -1056,6 +1056,8 @@
       },
       "delete": {
         "operationId": "deleteConnection",
+        "summary": "Delete Connection",
+        "description": "Delete a connection",
         "security": [
           {
             "ApiKey": []
@@ -1700,6 +1702,7 @@
       },
       "post": {
         "operationId": "createConnection",
+        "summary": "Create Connection",
         "description": "Import an existing connection after validation",
         "security": [
           {
@@ -2148,604 +2151,6 @@
         }
       }
     },
-    "/connect/pre-connect": {
-      "post": {
-        "operationId": "preConnect",
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "CustomerToken": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Must correspond to data.connector_name.\nTechnically id should imply connector_name already but there is no way to\nspecify a discriminated union with id alone."
-                  },
-                  "options": {
-                    "type": "object",
-                    "properties": {
-                      "integrationExternalId": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "number"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "connectionExternalId": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "number"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  "data": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/connectors.aircall.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.airtable.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.apollo.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.brex.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.coda.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.confluence.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.discord.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.facebook.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.finch.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.firebase.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.foreceipt.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.github.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.gong.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.googlecalendar.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.googledocs.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.googledrive.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.googlemail.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.googlesheet.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.greenhouse.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.heron.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.hubspot.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.instagram.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.intercom.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.jira.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.kustomer.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.lever.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.linear.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.linkedin.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.lunchmoney.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.mercury.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.merge.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.microsoft.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.moota.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.notion.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.onebrick.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.outreach.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.pipedrive.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.plaid.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.postgres.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.quickbooks.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.ramp.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.reddit.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.salesforce.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.salesloft.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.saltedge.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.sharepointonline.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.slack.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.splitwise.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.stripe.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.teller.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.toggl.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.twenty.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.twitter.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.venmo.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.wise.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.xero.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.yodlee.preConnectInput"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connectors.zohodesk.preConnectInput"
-                      }
-                    ],
-                    "discriminator": {
-                      "propertyName": "connector_name",
-                      "mapping": {
-                        "aircall": "#/components/schemas/connectors.aircall.preConnectInput",
-                        "airtable": "#/components/schemas/connectors.airtable.preConnectInput",
-                        "apollo": "#/components/schemas/connectors.apollo.preConnectInput",
-                        "brex": "#/components/schemas/connectors.brex.preConnectInput",
-                        "coda": "#/components/schemas/connectors.coda.preConnectInput",
-                        "confluence": "#/components/schemas/connectors.confluence.preConnectInput",
-                        "discord": "#/components/schemas/connectors.discord.preConnectInput",
-                        "facebook": "#/components/schemas/connectors.facebook.preConnectInput",
-                        "finch": "#/components/schemas/connectors.finch.preConnectInput",
-                        "firebase": "#/components/schemas/connectors.firebase.preConnectInput",
-                        "foreceipt": "#/components/schemas/connectors.foreceipt.preConnectInput",
-                        "github": "#/components/schemas/connectors.github.preConnectInput",
-                        "gong": "#/components/schemas/connectors.gong.preConnectInput",
-                        "googlecalendar": "#/components/schemas/connectors.googlecalendar.preConnectInput",
-                        "googledocs": "#/components/schemas/connectors.googledocs.preConnectInput",
-                        "googledrive": "#/components/schemas/connectors.googledrive.preConnectInput",
-                        "googlemail": "#/components/schemas/connectors.googlemail.preConnectInput",
-                        "googlesheet": "#/components/schemas/connectors.googlesheet.preConnectInput",
-                        "greenhouse": "#/components/schemas/connectors.greenhouse.preConnectInput",
-                        "heron": "#/components/schemas/connectors.heron.preConnectInput",
-                        "hubspot": "#/components/schemas/connectors.hubspot.preConnectInput",
-                        "instagram": "#/components/schemas/connectors.instagram.preConnectInput",
-                        "intercom": "#/components/schemas/connectors.intercom.preConnectInput",
-                        "jira": "#/components/schemas/connectors.jira.preConnectInput",
-                        "kustomer": "#/components/schemas/connectors.kustomer.preConnectInput",
-                        "lever": "#/components/schemas/connectors.lever.preConnectInput",
-                        "linear": "#/components/schemas/connectors.linear.preConnectInput",
-                        "linkedin": "#/components/schemas/connectors.linkedin.preConnectInput",
-                        "lunchmoney": "#/components/schemas/connectors.lunchmoney.preConnectInput",
-                        "mercury": "#/components/schemas/connectors.mercury.preConnectInput",
-                        "merge": "#/components/schemas/connectors.merge.preConnectInput",
-                        "microsoft": "#/components/schemas/connectors.microsoft.preConnectInput",
-                        "moota": "#/components/schemas/connectors.moota.preConnectInput",
-                        "notion": "#/components/schemas/connectors.notion.preConnectInput",
-                        "onebrick": "#/components/schemas/connectors.onebrick.preConnectInput",
-                        "outreach": "#/components/schemas/connectors.outreach.preConnectInput",
-                        "pipedrive": "#/components/schemas/connectors.pipedrive.preConnectInput",
-                        "plaid": "#/components/schemas/connectors.plaid.preConnectInput",
-                        "postgres": "#/components/schemas/connectors.postgres.preConnectInput",
-                        "quickbooks": "#/components/schemas/connectors.quickbooks.preConnectInput",
-                        "ramp": "#/components/schemas/connectors.ramp.preConnectInput",
-                        "reddit": "#/components/schemas/connectors.reddit.preConnectInput",
-                        "salesforce": "#/components/schemas/connectors.salesforce.preConnectInput",
-                        "salesloft": "#/components/schemas/connectors.salesloft.preConnectInput",
-                        "saltedge": "#/components/schemas/connectors.saltedge.preConnectInput",
-                        "sharepointonline": "#/components/schemas/connectors.sharepointonline.preConnectInput",
-                        "slack": "#/components/schemas/connectors.slack.preConnectInput",
-                        "splitwise": "#/components/schemas/connectors.splitwise.preConnectInput",
-                        "stripe": "#/components/schemas/connectors.stripe.preConnectInput",
-                        "teller": "#/components/schemas/connectors.teller.preConnectInput",
-                        "toggl": "#/components/schemas/connectors.toggl.preConnectInput",
-                        "twenty": "#/components/schemas/connectors.twenty.preConnectInput",
-                        "twitter": "#/components/schemas/connectors.twitter.preConnectInput",
-                        "venmo": "#/components/schemas/connectors.venmo.preConnectInput",
-                        "wise": "#/components/schemas/connectors.wise.preConnectInput",
-                        "xero": "#/components/schemas/connectors.xero.preConnectInput",
-                        "yodlee": "#/components/schemas/connectors.yodlee.preConnectInput",
-                        "zohodesk": "#/components/schemas/connectors.zohodesk.preConnectInput"
-                      }
-                    },
-                    "description": "Connector specific data"
-                  }
-                },
-                "required": [
-                  "id",
-                  "options",
-                  "data"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/connectors.aircall.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.airtable.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.apollo.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.brex.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.coda.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.confluence.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.discord.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.facebook.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.finch.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.firebase.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.foreceipt.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.github.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.gong.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.googlecalendar.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.googledocs.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.googledrive.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.googlemail.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.googlesheet.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.greenhouse.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.heron.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.hubspot.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.instagram.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.intercom.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.jira.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.kustomer.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.lever.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.linear.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.linkedin.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.lunchmoney.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.mercury.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.merge.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.microsoft.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.moota.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.notion.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.onebrick.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.outreach.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.pipedrive.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.plaid.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.postgres.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.quickbooks.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.ramp.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.reddit.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.salesforce.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.salesloft.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.saltedge.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.sharepointonline.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.slack.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.splitwise.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.stripe.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.teller.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.toggl.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.twenty.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.twitter.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.venmo.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.wise.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.xero.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.yodlee.connectInput"
-                    },
-                    {
-                      "$ref": "#/components/schemas/connectors.zohodesk.connectInput"
-                    }
-                  ],
-                  "discriminator": {
-                    "propertyName": "connector_name",
-                    "mapping": {
-                      "aircall": "#/components/schemas/connectors.aircall.connectInput",
-                      "airtable": "#/components/schemas/connectors.airtable.connectInput",
-                      "apollo": "#/components/schemas/connectors.apollo.connectInput",
-                      "brex": "#/components/schemas/connectors.brex.connectInput",
-                      "coda": "#/components/schemas/connectors.coda.connectInput",
-                      "confluence": "#/components/schemas/connectors.confluence.connectInput",
-                      "discord": "#/components/schemas/connectors.discord.connectInput",
-                      "facebook": "#/components/schemas/connectors.facebook.connectInput",
-                      "finch": "#/components/schemas/connectors.finch.connectInput",
-                      "firebase": "#/components/schemas/connectors.firebase.connectInput",
-                      "foreceipt": "#/components/schemas/connectors.foreceipt.connectInput",
-                      "github": "#/components/schemas/connectors.github.connectInput",
-                      "gong": "#/components/schemas/connectors.gong.connectInput",
-                      "googlecalendar": "#/components/schemas/connectors.googlecalendar.connectInput",
-                      "googledocs": "#/components/schemas/connectors.googledocs.connectInput",
-                      "googledrive": "#/components/schemas/connectors.googledrive.connectInput",
-                      "googlemail": "#/components/schemas/connectors.googlemail.connectInput",
-                      "googlesheet": "#/components/schemas/connectors.googlesheet.connectInput",
-                      "greenhouse": "#/components/schemas/connectors.greenhouse.connectInput",
-                      "heron": "#/components/schemas/connectors.heron.connectInput",
-                      "hubspot": "#/components/schemas/connectors.hubspot.connectInput",
-                      "instagram": "#/components/schemas/connectors.instagram.connectInput",
-                      "intercom": "#/components/schemas/connectors.intercom.connectInput",
-                      "jira": "#/components/schemas/connectors.jira.connectInput",
-                      "kustomer": "#/components/schemas/connectors.kustomer.connectInput",
-                      "lever": "#/components/schemas/connectors.lever.connectInput",
-                      "linear": "#/components/schemas/connectors.linear.connectInput",
-                      "linkedin": "#/components/schemas/connectors.linkedin.connectInput",
-                      "lunchmoney": "#/components/schemas/connectors.lunchmoney.connectInput",
-                      "mercury": "#/components/schemas/connectors.mercury.connectInput",
-                      "merge": "#/components/schemas/connectors.merge.connectInput",
-                      "microsoft": "#/components/schemas/connectors.microsoft.connectInput",
-                      "moota": "#/components/schemas/connectors.moota.connectInput",
-                      "notion": "#/components/schemas/connectors.notion.connectInput",
-                      "onebrick": "#/components/schemas/connectors.onebrick.connectInput",
-                      "outreach": "#/components/schemas/connectors.outreach.connectInput",
-                      "pipedrive": "#/components/schemas/connectors.pipedrive.connectInput",
-                      "plaid": "#/components/schemas/connectors.plaid.connectInput",
-                      "postgres": "#/components/schemas/connectors.postgres.connectInput",
-                      "quickbooks": "#/components/schemas/connectors.quickbooks.connectInput",
-                      "ramp": "#/components/schemas/connectors.ramp.connectInput",
-                      "reddit": "#/components/schemas/connectors.reddit.connectInput",
-                      "salesforce": "#/components/schemas/connectors.salesforce.connectInput",
-                      "salesloft": "#/components/schemas/connectors.salesloft.connectInput",
-                      "saltedge": "#/components/schemas/connectors.saltedge.connectInput",
-                      "sharepointonline": "#/components/schemas/connectors.sharepointonline.connectInput",
-                      "slack": "#/components/schemas/connectors.slack.connectInput",
-                      "splitwise": "#/components/schemas/connectors.splitwise.connectInput",
-                      "stripe": "#/components/schemas/connectors.stripe.connectInput",
-                      "teller": "#/components/schemas/connectors.teller.connectInput",
-                      "toggl": "#/components/schemas/connectors.toggl.connectInput",
-                      "twenty": "#/components/schemas/connectors.twenty.connectInput",
-                      "twitter": "#/components/schemas/connectors.twitter.connectInput",
-                      "venmo": "#/components/schemas/connectors.venmo.connectInput",
-                      "wise": "#/components/schemas/connectors.wise.connectInput",
-                      "xero": "#/components/schemas/connectors.xero.connectInput",
-                      "yodlee": "#/components/schemas/connectors.yodlee.connectInput",
-                      "zohodesk": "#/components/schemas/connectors.zohodesk.connectInput"
-                    }
-                  },
-                  "description": "Connector specific data"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.BAD_REQUEST"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authorization not provided",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient access",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.FORBIDDEN"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/customer/{customer_id}/magic-link": {
       "post": {
         "operationId": "createMagicLink",
@@ -3051,361 +2456,6 @@
           }
         }
       }
-    },
-    "/customers": {
-      "get": {
-        "operationId": "listCustomers",
-        "summary": "List Customers",
-        "description": "List all customers",
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "CustomerToken": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Limit the number of items returned",
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 100,
-              "default": 50,
-              "description": "Limit the number of items returned"
-            }
-          },
-          {
-            "in": "query",
-            "name": "offset",
-            "description": "Offset the items returned",
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "description": "Offset the items returned"
-            }
-          },
-          {
-            "in": "query",
-            "name": "keywords",
-            "schema": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/core.customer"
-                      }
-                    },
-                    "total": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "description": "Total number of items in the database for the organization"
-                    },
-                    "limit": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "maximum": 100,
-                      "default": 50,
-                      "description": "Limit the number of items returned"
-                    },
-                    "offset": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "default": 0,
-                      "description": "Offset the items returned"
-                    }
-                  },
-                  "required": [
-                    "items",
-                    "total",
-                    "limit",
-                    "offset"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.BAD_REQUEST"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authorization not provided",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient access",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.FORBIDDEN"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.NOT_FOUND"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "operationId": "health",
-        "summary": "Health Check",
-        "description": "Check if the API is operational",
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "CustomerToken": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authorization not provided",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient access",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.FORBIDDEN"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "healthEcho",
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "CustomerToken": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.BAD_REQUEST"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authorization not provided",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient access",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.FORBIDDEN"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/viewer": {
-      "get": {
-        "operationId": "viewer",
-        "summary": "Get Current User",
-        "description": "Get information about the current authenticated user",
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "CustomerToken": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "role": {
-                      "type": "string",
-                      "enum": [
-                        "customer",
-                        "org",
-                        "anon",
-                        "user"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "role"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authorization not provided",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient access",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.FORBIDDEN"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components": {
@@ -3432,31 +2482,6 @@
           "API_KEY"
         ],
         "title": "AuthMode"
-      },
-      "connectors.aircall.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "aircall"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "aircall"
       },
       "connectors.aircall.connectionSettings": {
         "type": "object",
@@ -3596,40 +2621,6 @@
         ],
         "title": "aircall"
       },
-      "connectors.aircall.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "aircall"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "aircall"
-      },
-      "connectors.airtable.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "airtable"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "airtable"
-      },
       "connectors.airtable.connectionSettings": {
         "type": "object",
         "properties": {
@@ -3675,40 +2666,6 @@
           "config"
         ],
         "title": "airtable"
-      },
-      "connectors.airtable.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "airtable"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "airtable"
-      },
-      "connectors.apollo.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "apollo"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "apollo"
       },
       "connectors.apollo.connectionSettings": {
         "type": "object",
@@ -3884,40 +2841,6 @@
         ],
         "title": "apollo"
       },
-      "connectors.apollo.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "apollo"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "apollo"
-      },
-      "connectors.brex.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "brex"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "brex"
-      },
       "connectors.brex.connectionSettings": {
         "type": "object",
         "properties": {
@@ -3991,40 +2914,6 @@
         ],
         "title": "brex"
       },
-      "connectors.brex.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "brex"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "brex"
-      },
-      "connectors.coda.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "coda"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "coda"
-      },
       "connectors.coda.connectionSettings": {
         "type": "object",
         "properties": {
@@ -4066,48 +2955,6 @@
           "config"
         ],
         "title": "coda"
-      },
-      "connectors.coda.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "coda"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "coda"
-      },
-      "connectors.confluence.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "confluence"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "confluence"
       },
       "connectors.confluence.connectionSettings": {
         "type": "object",
@@ -4247,48 +3094,6 @@
         ],
         "title": "confluence"
       },
-      "connectors.confluence.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "confluence"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "confluence"
-      },
-      "connectors.discord.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "discord"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "discord"
-      },
       "connectors.discord.connectionSettings": {
         "type": "object",
         "properties": {
@@ -4426,40 +3231,6 @@
           "config"
         ],
         "title": "discord"
-      },
-      "connectors.discord.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "discord"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "discord"
-      },
-      "connectors.facebook.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "facebook"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "facebook"
       },
       "connectors.facebook.connectionSettings": {
         "type": "object",
@@ -4658,65 +3429,6 @@
         ],
         "title": "facebook"
       },
-      "connectors.facebook.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "facebook"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "facebook"
-      },
-      "connectors.finch.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "finch"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "client_id": {
-                "type": "string"
-              },
-              "products": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "company",
-                    "directory",
-                    "individual",
-                    "ssn",
-                    "employment",
-                    "payment",
-                    "pay_statement",
-                    "benefits"
-                  ]
-                }
-              }
-            },
-            "required": [
-              "client_id",
-              "products"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "finch"
-      },
       "connectors.finch.connectionSettings": {
         "type": "object",
         "properties": {
@@ -4792,45 +3504,6 @@
           "config"
         ],
         "title": "finch"
-      },
-      "connectors.finch.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "finch"
-          },
-          "input": {
-            "type": "object",
-            "properties": {
-              "state": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "finch"
-      },
-      "connectors.firebase.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "firebase"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "firebase"
       },
       "connectors.firebase.connectionSettings": {
         "type": "object",
@@ -5016,54 +3689,6 @@
         ],
         "title": "firebase"
       },
-      "connectors.firebase.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "firebase"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "firebase"
-      },
-      "connectors.foreceipt.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "foreceipt"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "credentials": {},
-              "_id": {},
-              "envName": {
-                "type": "string",
-                "enum": [
-                  "staging",
-                  "production"
-                ]
-              }
-            },
-            "required": [
-              "envName"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "foreceipt"
-      },
       "connectors.foreceipt.connectionSettings": {
         "type": "object",
         "properties": {
@@ -5111,48 +3736,6 @@
           "config"
         ],
         "title": "foreceipt"
-      },
-      "connectors.foreceipt.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "foreceipt"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "foreceipt"
-      },
-      "connectors.github.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "github"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "github"
       },
       "connectors.github.connectionSettings": {
         "type": "object",
@@ -5291,40 +3874,6 @@
           "config"
         ],
         "title": "github"
-      },
-      "connectors.github.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "github"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "github"
-      },
-      "connectors.gong.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "gong"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "gong"
       },
       "connectors.gong.connectionSettings": {
         "type": "object",
@@ -5523,48 +4072,6 @@
         ],
         "title": "gong"
       },
-      "connectors.gong.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "gong"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "gong"
-      },
-      "connectors.googlecalendar.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googlecalendar"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "googlecalendar"
-      },
       "connectors.googlecalendar.connectionSettings": {
         "type": "object",
         "properties": {
@@ -5702,48 +4209,6 @@
           "config"
         ],
         "title": "googlecalendar"
-      },
-      "connectors.googlecalendar.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googlecalendar"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "googlecalendar"
-      },
-      "connectors.googledocs.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googledocs"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "googledocs"
       },
       "connectors.googledocs.connectionSettings": {
         "type": "object",
@@ -5883,48 +4348,6 @@
         ],
         "title": "googledocs"
       },
-      "connectors.googledocs.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googledocs"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "googledocs"
-      },
-      "connectors.googledrive.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googledrive"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "googledrive"
-      },
       "connectors.googledrive.connectionSettings": {
         "type": "object",
         "properties": {
@@ -6062,48 +4485,6 @@
           "config"
         ],
         "title": "googledrive"
-      },
-      "connectors.googledrive.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googledrive"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "googledrive"
-      },
-      "connectors.googlemail.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googlemail"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "googlemail"
       },
       "connectors.googlemail.connectionSettings": {
         "type": "object",
@@ -6243,48 +4624,6 @@
         ],
         "title": "googlemail"
       },
-      "connectors.googlemail.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googlemail"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "googlemail"
-      },
-      "connectors.googlesheet.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googlesheet"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "googlesheet"
-      },
       "connectors.googlesheet.connectionSettings": {
         "type": "object",
         "properties": {
@@ -6423,37 +4762,6 @@
         ],
         "title": "googlesheet"
       },
-      "connectors.googlesheet.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "googlesheet"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "googlesheet"
-      },
-      "connectors.greenhouse.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "greenhouse"
-          },
-          "output": {}
-        },
-        "required": [
-          "connector_name"
-        ],
-        "title": "greenhouse"
-      },
       "connectors.greenhouse.connectionSettings": {
         "type": "object",
         "properties": {
@@ -6496,37 +4804,6 @@
         ],
         "title": "greenhouse"
       },
-      "connectors.greenhouse.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "greenhouse"
-          },
-          "input": {}
-        },
-        "required": [
-          "connector_name"
-        ],
-        "title": "greenhouse"
-      },
-      "connectors.heron.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "heron"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "heron"
-      },
       "connectors.heron.connectionSettings": {
         "type": "object",
         "properties": {
@@ -6568,48 +4845,6 @@
           "config"
         ],
         "title": "heron"
-      },
-      "connectors.heron.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "heron"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "heron"
-      },
-      "connectors.hubspot.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "hubspot"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "hubspot"
       },
       "connectors.hubspot.connectionSettings": {
         "type": "object",
@@ -6748,40 +4983,6 @@
           "config"
         ],
         "title": "hubspot"
-      },
-      "connectors.hubspot.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "hubspot"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "hubspot"
-      },
-      "connectors.instagram.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "instagram"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "instagram"
       },
       "connectors.instagram.connectionSettings": {
         "type": "object",
@@ -6980,40 +5181,6 @@
         ],
         "title": "instagram"
       },
-      "connectors.instagram.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "instagram"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "instagram"
-      },
-      "connectors.intercom.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "intercom"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "intercom"
-      },
       "connectors.intercom.connectionSettings": {
         "type": "object",
         "properties": {
@@ -7210,40 +5377,6 @@
           "config"
         ],
         "title": "intercom"
-      },
-      "connectors.intercom.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "intercom"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "intercom"
-      },
-      "connectors.jira.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "jira"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "jira"
       },
       "connectors.jira.connectionSettings": {
         "type": "object",
@@ -7442,40 +5575,6 @@
         ],
         "title": "jira"
       },
-      "connectors.jira.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "jira"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "jira"
-      },
-      "connectors.kustomer.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "kustomer"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "kustomer"
-      },
       "connectors.kustomer.connectionSettings": {
         "type": "object",
         "properties": {
@@ -7672,40 +5771,6 @@
           "config"
         ],
         "title": "kustomer"
-      },
-      "connectors.kustomer.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "kustomer"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "kustomer"
-      },
-      "connectors.lever.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "lever"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "lever"
       },
       "connectors.lever.connectionSettings": {
         "type": "object",
@@ -7912,48 +5977,6 @@
         ],
         "title": "lever"
       },
-      "connectors.lever.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "lever"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "lever"
-      },
-      "connectors.linear.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "linear"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "linear"
-      },
       "connectors.linear.connectionSettings": {
         "type": "object",
         "properties": {
@@ -8091,48 +6114,6 @@
           "config"
         ],
         "title": "linear"
-      },
-      "connectors.linear.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "linear"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "linear"
-      },
-      "connectors.linkedin.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "linkedin"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "linkedin"
       },
       "connectors.linkedin.connectionSettings": {
         "type": "object",
@@ -8272,40 +6253,6 @@
         ],
         "title": "linkedin"
       },
-      "connectors.linkedin.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "linkedin"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "linkedin"
-      },
-      "connectors.lunchmoney.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "lunchmoney"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "lunchmoney"
-      },
       "connectors.lunchmoney.connectionSettings": {
         "type": "object",
         "properties": {
@@ -8347,40 +6294,6 @@
           "config"
         ],
         "title": "lunchmoney"
-      },
-      "connectors.lunchmoney.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "lunchmoney"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "lunchmoney"
-      },
-      "connectors.mercury.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "mercury"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "mercury"
       },
       "connectors.mercury.connectionSettings": {
         "type": "object",
@@ -8447,48 +6360,6 @@
         ],
         "title": "mercury"
       },
-      "connectors.mercury.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "mercury"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "mercury"
-      },
-      "connectors.merge.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "merge"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "link_token": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "link_token"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "merge"
-      },
       "connectors.merge.connectionSettings": {
         "type": "object",
         "properties": {
@@ -8539,55 +6410,6 @@
           "config"
         ],
         "title": "merge"
-      },
-      "connectors.merge.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "merge"
-          },
-          "input": {
-            "type": "object",
-            "properties": {
-              "categories": {
-                "type": "array",
-                "items": {}
-              },
-              "customer_email_address": {
-                "type": "string"
-              },
-              "customer_organization_name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "categories"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "merge"
-      },
-      "connectors.microsoft.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "microsoft"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "microsoft"
       },
       "connectors.microsoft.connectionSettings": {
         "type": "object",
@@ -8832,40 +6654,6 @@
         ],
         "title": "microsoft"
       },
-      "connectors.microsoft.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "microsoft"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "microsoft"
-      },
-      "connectors.moota.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "moota"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "moota"
-      },
       "connectors.moota.connectionSettings": {
         "type": "object",
         "properties": {
@@ -8907,48 +6695,6 @@
           "config"
         ],
         "title": "moota"
-      },
-      "connectors.moota.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "moota"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "moota"
-      },
-      "connectors.notion.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "notion"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "notion"
       },
       "connectors.notion.connectionSettings": {
         "type": "object",
@@ -9088,54 +6834,6 @@
         ],
         "title": "notion"
       },
-      "connectors.notion.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "notion"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "notion"
-      },
-      "connectors.onebrick.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "onebrick"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "publicToken": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "redirect_url": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            }
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "onebrick"
-      },
       "connectors.onebrick.connectionSettings": {
         "type": "object",
         "properties": {
@@ -9213,40 +6911,6 @@
           "config"
         ],
         "title": "onebrick"
-      },
-      "connectors.onebrick.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "onebrick"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "onebrick"
-      },
-      "connectors.outreach.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "outreach"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "outreach"
       },
       "connectors.outreach.connectionSettings": {
         "type": "object",
@@ -9445,40 +7109,6 @@
         ],
         "title": "outreach"
       },
-      "connectors.outreach.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "outreach"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "outreach"
-      },
-      "connectors.pipedrive.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "pipedrive"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "pipedrive"
-      },
       "connectors.pipedrive.connectionSettings": {
         "type": "object",
         "properties": {
@@ -9676,63 +7306,6 @@
         ],
         "title": "pipedrive"
       },
-      "connectors.pipedrive.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "pipedrive"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "pipedrive"
-      },
-      "connectors.plaid.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "plaid"
-          },
-          "output": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "link_token": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "link_token"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "public_token": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "public_token"
-                ]
-              }
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "plaid"
-      },
       "connectors.plaid.connectionSettings": {
         "type": "object",
         "properties": {
@@ -9901,55 +7474,6 @@
         ],
         "title": "plaid"
       },
-      "connectors.plaid.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "plaid"
-          },
-          "input": {
-            "type": "object",
-            "properties": {
-              "sandboxPublicTokenCreate": {
-                "type": "boolean"
-              },
-              "language": {
-                "type": "string",
-                "enum": [
-                  "en",
-                  "fr",
-                  "es",
-                  "nl",
-                  "de"
-                ]
-              }
-            }
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "plaid"
-      },
-      "connectors.postgres.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "postgres"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "postgres"
-      },
       "connectors.postgres.connectionSettings": {
         "type": "object",
         "properties": {
@@ -10003,48 +7527,6 @@
           "config"
         ],
         "title": "postgres"
-      },
-      "connectors.postgres.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "postgres"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "postgres"
-      },
-      "connectors.quickbooks.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "quickbooks"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "quickbooks"
       },
       "connectors.quickbooks.connectionSettings": {
         "type": "object",
@@ -10190,48 +7672,6 @@
         ],
         "title": "quickbooks"
       },
-      "connectors.quickbooks.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "quickbooks"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "quickbooks"
-      },
-      "connectors.ramp.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "ramp"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "accessToken": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            }
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "ramp"
-      },
       "connectors.ramp.connectionSettings": {
         "type": "object",
         "properties": {
@@ -10299,40 +7739,6 @@
           "config"
         ],
         "title": "ramp"
-      },
-      "connectors.ramp.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "ramp"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "ramp"
-      },
-      "connectors.reddit.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "reddit"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "reddit"
       },
       "connectors.reddit.connectionSettings": {
         "type": "object",
@@ -10531,48 +7937,6 @@
         ],
         "title": "reddit"
       },
-      "connectors.reddit.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "reddit"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "reddit"
-      },
-      "connectors.salesforce.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "salesforce"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "salesforce"
-      },
       "connectors.salesforce.connectionSettings": {
         "type": "object",
         "properties": {
@@ -10716,40 +8080,6 @@
           "config"
         ],
         "title": "salesforce"
-      },
-      "connectors.salesforce.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "salesforce"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "salesforce"
-      },
-      "connectors.salesloft.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "salesloft"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "salesloft"
       },
       "connectors.salesloft.connectionSettings": {
         "type": "object",
@@ -10948,40 +8278,6 @@
         ],
         "title": "salesloft"
       },
-      "connectors.salesloft.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "salesloft"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "salesloft"
-      },
-      "connectors.saltedge.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "saltedge"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "saltedge"
-      },
       "connectors.saltedge.connectionSettings": {
         "type": "object",
         "properties": {
@@ -11030,48 +8326,6 @@
           "config"
         ],
         "title": "saltedge"
-      },
-      "connectors.saltedge.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "saltedge"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "saltedge"
-      },
-      "connectors.sharepointonline.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "sharepointonline"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "sharepointonline"
       },
       "connectors.sharepointonline.connectionSettings": {
         "type": "object",
@@ -11211,48 +8465,6 @@
         ],
         "title": "sharepointonline"
       },
-      "connectors.sharepointonline.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "sharepointonline"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "sharepointonline"
-      },
-      "connectors.slack.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "slack"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "authorization_url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "authorization_url"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "slack"
-      },
       "connectors.slack.connectionSettings": {
         "type": "object",
         "properties": {
@@ -11390,40 +8602,6 @@
           "config"
         ],
         "title": "slack"
-      },
-      "connectors.slack.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "slack"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "slack"
-      },
-      "connectors.splitwise.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "splitwise"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "splitwise"
       },
       "connectors.splitwise.connectionSettings": {
         "type": "object",
@@ -11615,40 +8793,6 @@
         ],
         "title": "splitwise"
       },
-      "connectors.splitwise.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "splitwise"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "splitwise"
-      },
-      "connectors.stripe.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "stripe"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "stripe"
-      },
       "connectors.stripe.connectionSettings": {
         "type": "object",
         "properties": {
@@ -11722,54 +8866,6 @@
         ],
         "title": "stripe"
       },
-      "connectors.stripe.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "stripe"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "stripe"
-      },
-      "connectors.teller.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "teller"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "applicationId": {
-                "type": "string"
-              },
-              "userToken": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "applicationId"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "teller"
-      },
       "connectors.teller.connectionSettings": {
         "type": "object",
         "properties": {
@@ -11826,48 +8922,6 @@
         ],
         "title": "teller"
       },
-      "connectors.teller.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "teller"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "teller"
-      },
-      "connectors.toggl.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "toggl"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "apiToken": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "apiToken"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "toggl"
-      },
       "connectors.toggl.connectionSettings": {
         "type": "object",
         "properties": {
@@ -11922,40 +8976,6 @@
         ],
         "title": "toggl"
       },
-      "connectors.toggl.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "toggl"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "toggl"
-      },
-      "connectors.twenty.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "twenty"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "twenty"
-      },
       "connectors.twenty.connectionSettings": {
         "type": "object",
         "properties": {
@@ -11997,40 +9017,6 @@
           "config"
         ],
         "title": "twenty"
-      },
-      "connectors.twenty.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "twenty"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "twenty"
-      },
-      "connectors.twitter.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "twitter"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "twitter"
       },
       "connectors.twitter.connectionSettings": {
         "type": "object",
@@ -12229,40 +9215,6 @@
         ],
         "title": "twitter"
       },
-      "connectors.twitter.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "twitter"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "twitter"
-      },
-      "connectors.venmo.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "venmo"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "venmo"
-      },
       "connectors.venmo.connectionSettings": {
         "type": "object",
         "properties": {
@@ -12333,60 +9285,6 @@
         ],
         "title": "venmo"
       },
-      "connectors.venmo.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "venmo"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "venmo"
-      },
-      "connectors.wise.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "wise"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "redirectUri": {
-                "type": "string"
-              },
-              "clientId": {
-                "type": "string"
-              },
-              "envName": {
-                "type": "string",
-                "enum": [
-                  "sandbox",
-                  "live"
-                ]
-              }
-            },
-            "required": [
-              "redirectUri",
-              "clientId",
-              "envName"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "wise"
-      },
       "connectors.wise.connectionSettings": {
         "type": "object",
         "properties": {
@@ -12438,40 +9336,6 @@
           "config"
         ],
         "title": "wise"
-      },
-      "connectors.wise.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "wise"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "wise"
-      },
-      "connectors.xero.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "xero"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "xero"
       },
       "connectors.xero.connectionSettings": {
         "type": "object",
@@ -12670,73 +9534,6 @@
         ],
         "title": "xero"
       },
-      "connectors.xero.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "xero"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "xero"
-      },
-      "connectors.yodlee.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "yodlee"
-          },
-          "output": {
-            "type": "object",
-            "properties": {
-              "accessToken": {
-                "type": "object",
-                "properties": {
-                  "accessToken": {
-                    "type": "string"
-                  },
-                  "issuedAt": {
-                    "type": "string"
-                  },
-                  "expiresIn": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "accessToken",
-                  "issuedAt",
-                  "expiresIn"
-                ]
-              },
-              "envName": {
-                "type": "string",
-                "enum": [
-                  "sandbox",
-                  "development",
-                  "production"
-                ]
-              }
-            },
-            "required": [
-              "accessToken",
-              "envName"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "yodlee"
-      },
       "connectors.yodlee.connectionSettings": {
         "type": "object",
         "properties": {
@@ -12919,40 +9716,6 @@
           "config"
         ],
         "title": "yodlee"
-      },
-      "connectors.yodlee.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "yodlee"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
-        ],
-        "title": "yodlee"
-      },
-      "connectors.zohodesk.connectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "zohodesk"
-          },
-          "output": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "output"
-        ],
-        "title": "zohodesk"
       },
       "connectors.zohodesk.connectionSettings": {
         "type": "object",
@@ -13148,23 +9911,6 @@
         "required": [
           "connector_name",
           "config"
-        ],
-        "title": "zohodesk"
-      },
-      "connectors.zohodesk.preConnectInput": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "zohodesk"
-          },
-          "input": {
-            "type": "null"
-          }
-        },
-        "required": [
-          "connector_name",
-          "input"
         ],
         "title": "zohodesk"
       },
@@ -13512,30 +10258,6 @@
           "name"
         ],
         "title": "Connector"
-      },
-      "core.customer": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string"
-          },
-          "connection_count": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "id",
-          "updated_at",
-          "created_at",
-          "connection_count"
-        ],
-        "title": "Customer"
       },
       "core.integration": {
         "type": "object",

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -2456,6 +2456,146 @@
           }
         }
       }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health",
+        "summary": "Health Check",
+        "description": "Check if the API is operational",
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "CustomerToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "healthEcho",
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "CustomerToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/api-v1/__generated__/openapi.types.ts
+++ b/packages/api-v1/__generated__/openapi.types.ts
@@ -152,6 +152,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health Check
+         * @description Check if the API is operational
+         */
+        get: operations["health"];
+        put?: never;
+        post: operations["healthEcho"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3548,6 +3568,119 @@ export interface operations {
                     "application/json": {
                         /** @description The authentication token to use for API requests */
                         token: string;
+                    };
+                };
+            };
+            /** @description Invalid input data */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.BAD_REQUEST"];
+                };
+            };
+            /** @description Authorization not provided */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
+                };
+            };
+            /** @description Insufficient access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.FORBIDDEN"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
+                };
+            };
+        };
+    };
+    health: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ok: boolean;
+                    };
+                };
+            };
+            /** @description Authorization not provided */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
+                };
+            };
+            /** @description Insufficient access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.FORBIDDEN"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
+                };
+            };
+        };
+    };
+    healthEcho: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
                     };
                 };
             };

--- a/packages/api-v1/__generated__/openapi.types.ts
+++ b/packages/api-v1/__generated__/openapi.types.ts
@@ -12,8 +12,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List all connectors
-         * @description List all connectors with optional filtering
+         * List Connectors
+         * @description List all connectors to understand what integrations are available to configure
          */
         get: operations["listConnectors"];
         put?: never;
@@ -58,6 +58,10 @@ export interface paths {
         get: operations["getConnection"];
         put?: never;
         post?: never;
+        /**
+         * Delete Connection
+         * @description Delete a connection
+         */
         delete: operations["deleteConnection"];
         options?: never;
         head?: never;
@@ -77,7 +81,10 @@ export interface paths {
          */
         get: operations["listConnections"];
         put?: never;
-        /** @description Import an existing connection after validation */
+        /**
+         * Create Connection
+         * @description Import an existing connection after validation
+         */
         post: operations["createConnection"];
         delete?: never;
         options?: never;
@@ -99,22 +106,6 @@ export interface paths {
          * @description Verify that a connection is healthy
          */
         post: operations["checkConnection"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/connect/pre-connect": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["preConnect"];
         delete?: never;
         options?: never;
         head?: never;
@@ -161,66 +152,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/customers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Customers
-         * @description List all customers
-         */
-        get: operations["listCustomers"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health Check
-         * @description Check if the API is operational
-         */
-        get: operations["health"];
-        put?: never;
-        post: operations["healthEcho"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/viewer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Current User
-         * @description Get information about the current authenticated user
-         */
-        get: operations["viewer"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -230,17 +161,6 @@ export interface components {
          * @enum {string}
          */
         AuthMode: "OAUTH2" | "OAUTH1" | "BASIC" | "API_KEY";
-        /** aircall */
-        "connectors.aircall.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "aircall";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** aircall */
         "connectors.aircall.connectionSettings": {
             /**
@@ -288,24 +208,6 @@ export interface components {
                 } | null;
             };
         };
-        /** aircall */
-        "connectors.aircall.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "aircall";
-            input: null;
-        };
-        /** airtable */
-        "connectors.airtable.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "airtable";
-            output: null;
-        };
         /** airtable */
         "connectors.airtable.connectionSettings": {
             /**
@@ -326,24 +228,6 @@ export interface components {
              */
             connector_name: "airtable";
             config: null;
-        };
-        /** airtable */
-        "connectors.airtable.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "airtable";
-            input: null;
-        };
-        /** apollo */
-        "connectors.apollo.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "apollo";
-            output: null;
         };
         /** apollo */
         "connectors.apollo.connectionSettings": {
@@ -399,24 +283,6 @@ export interface components {
             connector_name: "apollo";
             config: null;
         };
-        /** apollo */
-        "connectors.apollo.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "apollo";
-            input: null;
-        };
-        /** brex */
-        "connectors.brex.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "brex";
-            output: null;
-        };
         /** brex */
         "connectors.brex.connectionSettings": {
             /**
@@ -445,24 +311,6 @@ export interface components {
                 apikeyAuth?: boolean;
             };
         };
-        /** brex */
-        "connectors.brex.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "brex";
-            input: null;
-        };
-        /** coda */
-        "connectors.coda.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "coda";
-            output: null;
-        };
         /** coda */
         "connectors.coda.connectionSettings": {
             /**
@@ -482,26 +330,6 @@ export interface components {
              */
             connector_name: "coda";
             config: null;
-        };
-        /** coda */
-        "connectors.coda.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "coda";
-            input: null;
-        };
-        /** confluence */
-        "connectors.confluence.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "confluence";
-            output: {
-                authorization_url: string;
-            };
         };
         /** confluence */
         "connectors.confluence.connectionSettings": {
@@ -550,26 +378,6 @@ export interface components {
                 } | null;
             };
         };
-        /** confluence */
-        "connectors.confluence.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "confluence";
-            input: null;
-        };
-        /** discord */
-        "connectors.discord.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "discord";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** discord */
         "connectors.discord.connectionSettings": {
             /**
@@ -616,24 +424,6 @@ export interface components {
                     scopes?: string[] | null;
                 } | null;
             };
-        };
-        /** discord */
-        "connectors.discord.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "discord";
-            input: null;
-        };
-        /** facebook */
-        "connectors.facebook.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "facebook";
-            output: null;
         };
         /** facebook */
         "connectors.facebook.connectionSettings": {
@@ -695,27 +485,6 @@ export interface components {
                 };
             };
         };
-        /** facebook */
-        "connectors.facebook.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "facebook";
-            input: null;
-        };
-        /** finch */
-        "connectors.finch.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "finch";
-            output: {
-                client_id: string;
-                products: ("company" | "directory" | "individual" | "ssn" | "employment" | "payment" | "pay_statement" | "benefits")[];
-            };
-        };
         /** finch */
         "connectors.finch.connectionSettings": {
             /**
@@ -742,26 +511,6 @@ export interface components {
                 /** @description Finch products to access, @see https://developer.tryfinch.com/api-reference/development-guides/Permissions */
                 products: ("company" | "directory" | "individual" | "ssn" | "employment" | "payment" | "pay_statement" | "benefits")[];
             };
-        };
-        /** finch */
-        "connectors.finch.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "finch";
-            input: {
-                state?: string;
-            };
-        };
-        /** firebase */
-        "connectors.firebase.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "firebase";
-            output: null;
         };
         /** firebase */
         "connectors.firebase.connectionSettings": {
@@ -824,29 +573,6 @@ export interface components {
             connector_name: "firebase";
             config: null;
         };
-        /** firebase */
-        "connectors.firebase.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "firebase";
-            input: null;
-        };
-        /** foreceipt */
-        "connectors.foreceipt.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "foreceipt";
-            output: {
-                credentials?: unknown;
-                _id?: unknown;
-                /** @enum {string} */
-                envName: "staging" | "production";
-            };
-        };
         /** foreceipt */
         "connectors.foreceipt.connectionSettings": {
             /**
@@ -869,26 +595,6 @@ export interface components {
              */
             connector_name: "foreceipt";
             config: null;
-        };
-        /** foreceipt */
-        "connectors.foreceipt.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "foreceipt";
-            input: null;
-        };
-        /** github */
-        "connectors.github.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "github";
-            output: {
-                authorization_url: string;
-            };
         };
         /** github */
         "connectors.github.connectionSettings": {
@@ -936,24 +642,6 @@ export interface components {
                     scopes?: string[] | null;
                 } | null;
             };
-        };
-        /** github */
-        "connectors.github.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "github";
-            input: null;
-        };
-        /** gong */
-        "connectors.gong.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "gong";
-            output: null;
         };
         /** gong */
         "connectors.gong.connectionSettings": {
@@ -1015,26 +703,6 @@ export interface components {
                 };
             };
         };
-        /** gong */
-        "connectors.gong.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "gong";
-            input: null;
-        };
-        /** googlecalendar */
-        "connectors.googlecalendar.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googlecalendar";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** googlecalendar */
         "connectors.googlecalendar.connectionSettings": {
             /**
@@ -1080,26 +748,6 @@ export interface components {
                     client_secret?: string | null;
                     scopes?: string[] | null;
                 } | null;
-            };
-        };
-        /** googlecalendar */
-        "connectors.googlecalendar.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googlecalendar";
-            input: null;
-        };
-        /** googledocs */
-        "connectors.googledocs.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googledocs";
-            output: {
-                authorization_url: string;
             };
         };
         /** googledocs */
@@ -1149,26 +797,6 @@ export interface components {
                 } | null;
             };
         };
-        /** googledocs */
-        "connectors.googledocs.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googledocs";
-            input: null;
-        };
-        /** googledrive */
-        "connectors.googledrive.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googledrive";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** googledrive */
         "connectors.googledrive.connectionSettings": {
             /**
@@ -1214,26 +842,6 @@ export interface components {
                     client_secret?: string | null;
                     scopes?: string[] | null;
                 } | null;
-            };
-        };
-        /** googledrive */
-        "connectors.googledrive.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googledrive";
-            input: null;
-        };
-        /** googlemail */
-        "connectors.googlemail.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googlemail";
-            output: {
-                authorization_url: string;
             };
         };
         /** googlemail */
@@ -1283,26 +891,6 @@ export interface components {
                 } | null;
             };
         };
-        /** googlemail */
-        "connectors.googlemail.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googlemail";
-            input: null;
-        };
-        /** googlesheet */
-        "connectors.googlesheet.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googlesheet";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** googlesheet */
         "connectors.googlesheet.connectionSettings": {
             /**
@@ -1350,24 +938,6 @@ export interface components {
                 } | null;
             };
         };
-        /** googlesheet */
-        "connectors.googlesheet.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "googlesheet";
-            input: null;
-        };
-        /** greenhouse */
-        "connectors.greenhouse.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "greenhouse";
-            output?: unknown;
-        };
         /** greenhouse */
         "connectors.greenhouse.connectionSettings": {
             /**
@@ -1388,24 +958,6 @@ export interface components {
             connector_name: "greenhouse";
             config: null;
         };
-        /** greenhouse */
-        "connectors.greenhouse.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "greenhouse";
-            input?: unknown;
-        };
-        /** heron */
-        "connectors.heron.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "heron";
-            output: null;
-        };
         /** heron */
         "connectors.heron.connectionSettings": {
             /**
@@ -1424,26 +976,6 @@ export interface components {
             connector_name: "heron";
             config: {
                 apiKey: string;
-            };
-        };
-        /** heron */
-        "connectors.heron.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "heron";
-            input: null;
-        };
-        /** hubspot */
-        "connectors.hubspot.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "hubspot";
-            output: {
-                authorization_url: string;
             };
         };
         /** hubspot */
@@ -1492,24 +1024,6 @@ export interface components {
                     scopes?: string[] | null;
                 } | null;
             };
-        };
-        /** hubspot */
-        "connectors.hubspot.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "hubspot";
-            input: null;
-        };
-        /** instagram */
-        "connectors.instagram.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "instagram";
-            output: null;
         };
         /** instagram */
         "connectors.instagram.connectionSettings": {
@@ -1571,24 +1085,6 @@ export interface components {
                 };
             };
         };
-        /** instagram */
-        "connectors.instagram.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "instagram";
-            input: null;
-        };
-        /** intercom */
-        "connectors.intercom.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "intercom";
-            output: null;
-        };
         /** intercom */
         "connectors.intercom.connectionSettings": {
             /**
@@ -1648,24 +1144,6 @@ export interface components {
                     scopes?: string;
                 };
             };
-        };
-        /** intercom */
-        "connectors.intercom.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "intercom";
-            input: null;
-        };
-        /** jira */
-        "connectors.jira.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "jira";
-            output: null;
         };
         /** jira */
         "connectors.jira.connectionSettings": {
@@ -1727,24 +1205,6 @@ export interface components {
                 };
             };
         };
-        /** jira */
-        "connectors.jira.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "jira";
-            input: null;
-        };
-        /** kustomer */
-        "connectors.kustomer.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "kustomer";
-            output: null;
-        };
         /** kustomer */
         "connectors.kustomer.connectionSettings": {
             /**
@@ -1804,24 +1264,6 @@ export interface components {
                     scopes?: string;
                 };
             };
-        };
-        /** kustomer */
-        "connectors.kustomer.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "kustomer";
-            input: null;
-        };
-        /** lever */
-        "connectors.lever.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "lever";
-            output: null;
         };
         /** lever */
         "connectors.lever.connectionSettings": {
@@ -1885,26 +1327,6 @@ export interface components {
                 envName: "sandbox" | "production";
             };
         };
-        /** lever */
-        "connectors.lever.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "lever";
-            input: null;
-        };
-        /** linear */
-        "connectors.linear.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "linear";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** linear */
         "connectors.linear.connectionSettings": {
             /**
@@ -1950,26 +1372,6 @@ export interface components {
                     client_secret?: string | null;
                     scopes?: string[] | null;
                 } | null;
-            };
-        };
-        /** linear */
-        "connectors.linear.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "linear";
-            input: null;
-        };
-        /** linkedin */
-        "connectors.linkedin.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "linkedin";
-            output: {
-                authorization_url: string;
             };
         };
         /** linkedin */
@@ -2019,24 +1421,6 @@ export interface components {
                 } | null;
             };
         };
-        /** linkedin */
-        "connectors.linkedin.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "linkedin";
-            input: null;
-        };
-        /** lunchmoney */
-        "connectors.lunchmoney.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "lunchmoney";
-            output: null;
-        };
         /** lunchmoney */
         "connectors.lunchmoney.connectionSettings": {
             /**
@@ -2056,24 +1440,6 @@ export interface components {
             config: {
                 accessToken: string;
             };
-        };
-        /** lunchmoney */
-        "connectors.lunchmoney.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "lunchmoney";
-            input: null;
-        };
-        /** mercury */
-        "connectors.mercury.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "mercury";
-            output: null;
         };
         /** mercury */
         "connectors.mercury.connectionSettings": {
@@ -2101,26 +1467,6 @@ export interface components {
                 apikeyAuth?: boolean;
             };
         };
-        /** mercury */
-        "connectors.mercury.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "mercury";
-            input: null;
-        };
-        /** merge */
-        "connectors.merge.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "merge";
-            output: {
-                link_token: string;
-            };
-        };
         /** merge */
         "connectors.merge.connectionSettings": {
             /**
@@ -2143,28 +1489,6 @@ export interface components {
             config: {
                 apiKey: string;
             };
-        };
-        /** merge */
-        "connectors.merge.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "merge";
-            input: {
-                categories: unknown[];
-                customer_email_address?: string;
-                customer_organization_name?: string;
-            };
-        };
-        /** microsoft */
-        "connectors.microsoft.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "microsoft";
-            output: null;
         };
         /** microsoft */
         "connectors.microsoft.connectionSettings": {
@@ -2245,24 +1569,6 @@ export interface components {
                 };
             };
         };
-        /** microsoft */
-        "connectors.microsoft.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "microsoft";
-            input: null;
-        };
-        /** moota */
-        "connectors.moota.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "moota";
-            output: null;
-        };
         /** moota */
         "connectors.moota.connectionSettings": {
             /**
@@ -2281,26 +1587,6 @@ export interface components {
             connector_name: "moota";
             config: {
                 token: string;
-            };
-        };
-        /** moota */
-        "connectors.moota.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "moota";
-            input: null;
-        };
-        /** notion */
-        "connectors.notion.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "notion";
-            output: {
-                authorization_url: string;
             };
         };
         /** notion */
@@ -2350,27 +1636,6 @@ export interface components {
                 } | null;
             };
         };
-        /** notion */
-        "connectors.notion.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "notion";
-            input: null;
-        };
-        /** onebrick */
-        "connectors.onebrick.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "onebrick";
-            output: {
-                publicToken?: string | null;
-                redirect_url?: string | null;
-            };
-        };
         /** onebrick */
         "connectors.onebrick.connectionSettings": {
             /**
@@ -2398,24 +1663,6 @@ export interface components {
                 accessToken?: string | null;
                 redirectUrl?: string | null;
             };
-        };
-        /** onebrick */
-        "connectors.onebrick.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "onebrick";
-            input: null;
-        };
-        /** outreach */
-        "connectors.outreach.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "outreach";
-            output: null;
         };
         /** outreach */
         "connectors.outreach.connectionSettings": {
@@ -2477,24 +1724,6 @@ export interface components {
                 };
             };
         };
-        /** outreach */
-        "connectors.outreach.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "outreach";
-            input: null;
-        };
-        /** pipedrive */
-        "connectors.pipedrive.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "pipedrive";
-            output: null;
-        };
         /** pipedrive */
         "connectors.pipedrive.connectionSettings": {
             /**
@@ -2555,28 +1784,6 @@ export interface components {
                 };
             };
         };
-        /** pipedrive */
-        "connectors.pipedrive.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "pipedrive";
-            input: null;
-        };
-        /** plaid */
-        "connectors.plaid.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "plaid";
-            output: {
-                link_token: string;
-            } | {
-                public_token: string;
-            };
-        };
         /** plaid */
         "connectors.plaid.connectionSettings": {
             /**
@@ -2630,28 +1837,6 @@ export interface components {
                 language: "en" | "fr" | "es" | "nl" | "de";
             };
         };
-        /** plaid */
-        "connectors.plaid.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "plaid";
-            input: {
-                sandboxPublicTokenCreate?: boolean;
-                /** @enum {string} */
-                language?: "en" | "fr" | "es" | "nl" | "de";
-            };
-        };
-        /** postgres */
-        "connectors.postgres.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "postgres";
-            output: null;
-        };
         /** postgres */
         "connectors.postgres.connectionSettings": {
             /**
@@ -2675,26 +1860,6 @@ export interface components {
              */
             connector_name: "postgres";
             config: null;
-        };
-        /** postgres */
-        "connectors.postgres.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "postgres";
-            input: null;
-        };
-        /** quickbooks */
-        "connectors.quickbooks.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "quickbooks";
-            output: {
-                authorization_url: string;
-            };
         };
         /** quickbooks */
         "connectors.quickbooks.connectionSettings": {
@@ -2745,26 +1910,6 @@ export interface components {
                 } | null;
             };
         };
-        /** quickbooks */
-        "connectors.quickbooks.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "quickbooks";
-            input: null;
-        };
-        /** ramp */
-        "connectors.ramp.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "ramp";
-            output: {
-                accessToken?: string | null;
-            };
-        };
         /** ramp */
         "connectors.ramp.connectionSettings": {
             /**
@@ -2790,24 +1935,6 @@ export interface components {
                     clientSecret: string;
                 };
             };
-        };
-        /** ramp */
-        "connectors.ramp.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "ramp";
-            input: null;
-        };
-        /** reddit */
-        "connectors.reddit.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "reddit";
-            output: null;
         };
         /** reddit */
         "connectors.reddit.connectionSettings": {
@@ -2869,26 +1996,6 @@ export interface components {
                 };
             };
         };
-        /** reddit */
-        "connectors.reddit.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "reddit";
-            input: null;
-        };
-        /** salesforce */
-        "connectors.salesforce.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "salesforce";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** salesforce */
         "connectors.salesforce.connectionSettings": {
             /**
@@ -2937,24 +2044,6 @@ export interface components {
                     scopes?: string[] | null;
                 } | null;
             };
-        };
-        /** salesforce */
-        "connectors.salesforce.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "salesforce";
-            input: null;
-        };
-        /** salesloft */
-        "connectors.salesloft.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "salesloft";
-            output: null;
         };
         /** salesloft */
         "connectors.salesloft.connectionSettings": {
@@ -3016,24 +2105,6 @@ export interface components {
                 };
             };
         };
-        /** salesloft */
-        "connectors.salesloft.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "salesloft";
-            input: null;
-        };
-        /** saltedge */
-        "connectors.saltedge.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "saltedge";
-            output: null;
-        };
         /** saltedge */
         "connectors.saltedge.connectionSettings": {
             /**
@@ -3054,26 +2125,6 @@ export interface components {
                 appId: string;
                 secret: string;
                 url?: string | null;
-            };
-        };
-        /** saltedge */
-        "connectors.saltedge.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "saltedge";
-            input: null;
-        };
-        /** sharepointonline */
-        "connectors.sharepointonline.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "sharepointonline";
-            output: {
-                authorization_url: string;
             };
         };
         /** sharepointonline */
@@ -3123,26 +2174,6 @@ export interface components {
                 } | null;
             };
         };
-        /** sharepointonline */
-        "connectors.sharepointonline.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "sharepointonline";
-            input: null;
-        };
-        /** slack */
-        "connectors.slack.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "slack";
-            output: {
-                authorization_url: string;
-            };
-        };
         /** slack */
         "connectors.slack.connectionSettings": {
             /**
@@ -3189,24 +2220,6 @@ export interface components {
                     scopes?: string[] | null;
                 } | null;
             };
-        };
-        /** slack */
-        "connectors.slack.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "slack";
-            input: null;
-        };
-        /** splitwise */
-        "connectors.splitwise.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "splitwise";
-            output: null;
         };
         /** splitwise */
         "connectors.splitwise.connectionSettings": {
@@ -3262,24 +2275,6 @@ export interface components {
             connector_name: "splitwise";
             config: null;
         };
-        /** splitwise */
-        "connectors.splitwise.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "splitwise";
-            input: null;
-        };
-        /** stripe */
-        "connectors.stripe.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "stripe";
-            output: null;
-        };
         /** stripe */
         "connectors.stripe.connectionSettings": {
             /**
@@ -3308,27 +2303,6 @@ export interface components {
                 apikeyAuth?: boolean;
             };
         };
-        /** stripe */
-        "connectors.stripe.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "stripe";
-            input: null;
-        };
-        /** teller */
-        "connectors.teller.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "teller";
-            output: {
-                applicationId: string;
-                userToken?: string | null;
-            };
-        };
         /** teller */
         "connectors.teller.connectionSettings": {
             /**
@@ -3350,26 +2324,6 @@ export interface components {
             config: {
                 applicationId: string;
                 token?: string | null;
-            };
-        };
-        /** teller */
-        "connectors.teller.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "teller";
-            input: null;
-        };
-        /** toggl */
-        "connectors.toggl.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "toggl";
-            output: {
-                apiToken: string;
             };
         };
         /** toggl */
@@ -3394,24 +2348,6 @@ export interface components {
             connector_name: "toggl";
             config: null;
         };
-        /** toggl */
-        "connectors.toggl.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "toggl";
-            input: null;
-        };
-        /** twenty */
-        "connectors.twenty.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "twenty";
-            output: null;
-        };
         /** twenty */
         "connectors.twenty.connectionSettings": {
             /**
@@ -3431,24 +2367,6 @@ export interface components {
              */
             connector_name: "twenty";
             config: null;
-        };
-        /** twenty */
-        "connectors.twenty.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "twenty";
-            input: null;
-        };
-        /** twitter */
-        "connectors.twitter.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "twitter";
-            output: null;
         };
         /** twitter */
         "connectors.twitter.connectionSettings": {
@@ -3510,24 +2428,6 @@ export interface components {
                 };
             };
         };
-        /** twitter */
-        "connectors.twitter.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "twitter";
-            input: null;
-        };
-        /** venmo */
-        "connectors.venmo.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "venmo";
-            output: null;
-        };
         /** venmo */
         "connectors.venmo.connectionSettings": {
             /**
@@ -3556,29 +2456,6 @@ export interface components {
                 } | null;
             };
         };
-        /** venmo */
-        "connectors.venmo.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "venmo";
-            input: null;
-        };
-        /** wise */
-        "connectors.wise.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "wise";
-            output: {
-                redirectUri: string;
-                clientId: string;
-                /** @enum {string} */
-                envName: "sandbox" | "live";
-            };
-        };
         /** wise */
         "connectors.wise.connectionSettings": {
             /**
@@ -3600,24 +2477,6 @@ export interface components {
              */
             connector_name: "wise";
             config: null;
-        };
-        /** wise */
-        "connectors.wise.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "wise";
-            input: null;
-        };
-        /** xero */
-        "connectors.xero.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "xero";
-            output: null;
         };
         /** xero */
         "connectors.xero.connectionSettings": {
@@ -3679,32 +2538,6 @@ export interface components {
                 };
             };
         };
-        /** xero */
-        "connectors.xero.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "xero";
-            input: null;
-        };
-        /** yodlee */
-        "connectors.yodlee.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "yodlee";
-            output: {
-                accessToken: {
-                    accessToken: string;
-                    issuedAt: string;
-                    expiresIn: number;
-                };
-                /** @enum {string} */
-                envName: "sandbox" | "development" | "production";
-            };
-        };
         /** yodlee */
         "connectors.yodlee.connectionSettings": {
             /**
@@ -3754,24 +2587,6 @@ export interface components {
                     cert: string;
                 } | null;
             };
-        };
-        /** yodlee */
-        "connectors.yodlee.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "yodlee";
-            input: null;
-        };
-        /** zohodesk */
-        "connectors.zohodesk.connectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "zohodesk";
-            output: null;
         };
         /** zohodesk */
         "connectors.zohodesk.connectionSettings": {
@@ -3833,15 +2648,6 @@ export interface components {
                 };
             };
         };
-        /** zohodesk */
-        "connectors.zohodesk.preConnectInput": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "zohodesk";
-            input: null;
-        };
         /** Connection */
         "core.connection": {
             connector_name: "core.connection";
@@ -3873,13 +2679,6 @@ export interface components {
                 connect_input?: unknown;
                 connect_output?: unknown;
             };
-        };
-        /** Customer */
-        "core.customer": {
-            id: string;
-            updated_at: string;
-            created_at: string;
-            connection_count: number;
         };
         /** Integration */
         "core.integration": {
@@ -4625,77 +3424,6 @@ export interface operations {
             };
         };
     };
-    preConnect: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description Must correspond to data.connector_name.
-                     *     Technically id should imply connector_name already but there is no way to
-                     *     specify a discriminated union with id alone. */
-                    id: string;
-                    options: {
-                        integrationExternalId?: string | number | null;
-                        connectionExternalId?: string | number | null;
-                    };
-                    /** @description Connector specific data */
-                    data: components["schemas"]["connectors.aircall.preConnectInput"] | components["schemas"]["connectors.airtable.preConnectInput"] | components["schemas"]["connectors.apollo.preConnectInput"] | components["schemas"]["connectors.brex.preConnectInput"] | components["schemas"]["connectors.coda.preConnectInput"] | components["schemas"]["connectors.confluence.preConnectInput"] | components["schemas"]["connectors.discord.preConnectInput"] | components["schemas"]["connectors.facebook.preConnectInput"] | components["schemas"]["connectors.finch.preConnectInput"] | components["schemas"]["connectors.firebase.preConnectInput"] | components["schemas"]["connectors.foreceipt.preConnectInput"] | components["schemas"]["connectors.github.preConnectInput"] | components["schemas"]["connectors.gong.preConnectInput"] | components["schemas"]["connectors.googlecalendar.preConnectInput"] | components["schemas"]["connectors.googledocs.preConnectInput"] | components["schemas"]["connectors.googledrive.preConnectInput"] | components["schemas"]["connectors.googlemail.preConnectInput"] | components["schemas"]["connectors.googlesheet.preConnectInput"] | components["schemas"]["connectors.greenhouse.preConnectInput"] | components["schemas"]["connectors.heron.preConnectInput"] | components["schemas"]["connectors.hubspot.preConnectInput"] | components["schemas"]["connectors.instagram.preConnectInput"] | components["schemas"]["connectors.intercom.preConnectInput"] | components["schemas"]["connectors.jira.preConnectInput"] | components["schemas"]["connectors.kustomer.preConnectInput"] | components["schemas"]["connectors.lever.preConnectInput"] | components["schemas"]["connectors.linear.preConnectInput"] | components["schemas"]["connectors.linkedin.preConnectInput"] | components["schemas"]["connectors.lunchmoney.preConnectInput"] | components["schemas"]["connectors.mercury.preConnectInput"] | components["schemas"]["connectors.merge.preConnectInput"] | components["schemas"]["connectors.microsoft.preConnectInput"] | components["schemas"]["connectors.moota.preConnectInput"] | components["schemas"]["connectors.notion.preConnectInput"] | components["schemas"]["connectors.onebrick.preConnectInput"] | components["schemas"]["connectors.outreach.preConnectInput"] | components["schemas"]["connectors.pipedrive.preConnectInput"] | components["schemas"]["connectors.plaid.preConnectInput"] | components["schemas"]["connectors.postgres.preConnectInput"] | components["schemas"]["connectors.quickbooks.preConnectInput"] | components["schemas"]["connectors.ramp.preConnectInput"] | components["schemas"]["connectors.reddit.preConnectInput"] | components["schemas"]["connectors.salesforce.preConnectInput"] | components["schemas"]["connectors.salesloft.preConnectInput"] | components["schemas"]["connectors.saltedge.preConnectInput"] | components["schemas"]["connectors.sharepointonline.preConnectInput"] | components["schemas"]["connectors.slack.preConnectInput"] | components["schemas"]["connectors.splitwise.preConnectInput"] | components["schemas"]["connectors.stripe.preConnectInput"] | components["schemas"]["connectors.teller.preConnectInput"] | components["schemas"]["connectors.toggl.preConnectInput"] | components["schemas"]["connectors.twenty.preConnectInput"] | components["schemas"]["connectors.twitter.preConnectInput"] | components["schemas"]["connectors.venmo.preConnectInput"] | components["schemas"]["connectors.wise.preConnectInput"] | components["schemas"]["connectors.xero.preConnectInput"] | components["schemas"]["connectors.yodlee.preConnectInput"] | components["schemas"]["connectors.zohodesk.preConnectInput"];
-                };
-            };
-        };
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["connectors.aircall.connectInput"] | components["schemas"]["connectors.airtable.connectInput"] | components["schemas"]["connectors.apollo.connectInput"] | components["schemas"]["connectors.brex.connectInput"] | components["schemas"]["connectors.coda.connectInput"] | components["schemas"]["connectors.confluence.connectInput"] | components["schemas"]["connectors.discord.connectInput"] | components["schemas"]["connectors.facebook.connectInput"] | components["schemas"]["connectors.finch.connectInput"] | components["schemas"]["connectors.firebase.connectInput"] | components["schemas"]["connectors.foreceipt.connectInput"] | components["schemas"]["connectors.github.connectInput"] | components["schemas"]["connectors.gong.connectInput"] | components["schemas"]["connectors.googlecalendar.connectInput"] | components["schemas"]["connectors.googledocs.connectInput"] | components["schemas"]["connectors.googledrive.connectInput"] | components["schemas"]["connectors.googlemail.connectInput"] | components["schemas"]["connectors.googlesheet.connectInput"] | components["schemas"]["connectors.greenhouse.connectInput"] | components["schemas"]["connectors.heron.connectInput"] | components["schemas"]["connectors.hubspot.connectInput"] | components["schemas"]["connectors.instagram.connectInput"] | components["schemas"]["connectors.intercom.connectInput"] | components["schemas"]["connectors.jira.connectInput"] | components["schemas"]["connectors.kustomer.connectInput"] | components["schemas"]["connectors.lever.connectInput"] | components["schemas"]["connectors.linear.connectInput"] | components["schemas"]["connectors.linkedin.connectInput"] | components["schemas"]["connectors.lunchmoney.connectInput"] | components["schemas"]["connectors.mercury.connectInput"] | components["schemas"]["connectors.merge.connectInput"] | components["schemas"]["connectors.microsoft.connectInput"] | components["schemas"]["connectors.moota.connectInput"] | components["schemas"]["connectors.notion.connectInput"] | components["schemas"]["connectors.onebrick.connectInput"] | components["schemas"]["connectors.outreach.connectInput"] | components["schemas"]["connectors.pipedrive.connectInput"] | components["schemas"]["connectors.plaid.connectInput"] | components["schemas"]["connectors.postgres.connectInput"] | components["schemas"]["connectors.quickbooks.connectInput"] | components["schemas"]["connectors.ramp.connectInput"] | components["schemas"]["connectors.reddit.connectInput"] | components["schemas"]["connectors.salesforce.connectInput"] | components["schemas"]["connectors.salesloft.connectInput"] | components["schemas"]["connectors.saltedge.connectInput"] | components["schemas"]["connectors.sharepointonline.connectInput"] | components["schemas"]["connectors.slack.connectInput"] | components["schemas"]["connectors.splitwise.connectInput"] | components["schemas"]["connectors.stripe.connectInput"] | components["schemas"]["connectors.teller.connectInput"] | components["schemas"]["connectors.toggl.connectInput"] | components["schemas"]["connectors.twenty.connectInput"] | components["schemas"]["connectors.twitter.connectInput"] | components["schemas"]["connectors.venmo.connectInput"] | components["schemas"]["connectors.wise.connectInput"] | components["schemas"]["connectors.xero.connectInput"] | components["schemas"]["connectors.yodlee.connectInput"] | components["schemas"]["connectors.zohodesk.connectInput"];
-                };
-            };
-            /** @description Invalid input data */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.BAD_REQUEST"];
-                };
-            };
-            /** @description Authorization not provided */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
-                };
-            };
-            /** @description Insufficient access */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.FORBIDDEN"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
-                };
-            };
-        };
-    };
     createMagicLink: {
         parameters: {
             query?: never;
@@ -4830,254 +3558,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["error.BAD_REQUEST"];
-                };
-            };
-            /** @description Authorization not provided */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
-                };
-            };
-            /** @description Insufficient access */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.FORBIDDEN"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
-                };
-            };
-        };
-    };
-    listCustomers: {
-        parameters: {
-            query?: {
-                /** @description Limit the number of items returned */
-                limit?: number;
-                /** @description Offset the items returned */
-                offset?: number;
-                keywords?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        items: components["schemas"]["core.customer"][];
-                        /** @description Total number of items in the database for the organization */
-                        total: number;
-                        /**
-                         * @description Limit the number of items returned
-                         * @default 50
-                         */
-                        limit: number;
-                        /**
-                         * @description Offset the items returned
-                         * @default 0
-                         */
-                        offset: number;
-                    };
-                };
-            };
-            /** @description Invalid input data */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.BAD_REQUEST"];
-                };
-            };
-            /** @description Authorization not provided */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
-                };
-            };
-            /** @description Insufficient access */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.FORBIDDEN"];
-                };
-            };
-            /** @description Not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.NOT_FOUND"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
-                };
-            };
-        };
-    };
-    health: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        ok: boolean;
-                    };
-                };
-            };
-            /** @description Authorization not provided */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
-                };
-            };
-            /** @description Insufficient access */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.FORBIDDEN"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
-                };
-            };
-        };
-    };
-    healthEcho: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
-            };
-        };
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Invalid input data */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.BAD_REQUEST"];
-                };
-            };
-            /** @description Authorization not provided */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
-                };
-            };
-            /** @description Insufficient access */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.FORBIDDEN"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
-                };
-            };
-        };
-    };
-    viewer: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {string} */
-                        role: "customer" | "org" | "anon" | "user";
-                    };
                 };
             };
             /** @description Authorization not provided */

--- a/packages/api-v1/__generated__/openapi.types.ts
+++ b/packages/api-v1/__generated__/openapi.types.ts
@@ -172,6 +172,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/viewer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Current User
+         * @description Get information about the current authenticated user
+         */
+        get: operations["viewer"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3691,6 +3711,56 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["error.BAD_REQUEST"];
+                };
+            };
+            /** @description Authorization not provided */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.UNAUTHORIZED"];
+                };
+            };
+            /** @description Insufficient access */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.FORBIDDEN"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error.INTERNAL_SERVER_ERROR"];
+                };
+            };
+        };
+    };
+    viewer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        role: "customer" | "org" | "anon" | "user";
+                    };
                 };
             };
             /** @description Authorization not provided */

--- a/packages/api-v1/__tests__/app.spec.ts
+++ b/packages/api-v1/__tests__/app.spec.ts
@@ -5,10 +5,7 @@ import {initDbPGLite} from '@openint/db/db.pglite'
 import {loopbackLink} from '@openint/loopback-link'
 import type {paths} from '../__generated__/openapi.types'
 import {createApp} from '../app'
-import {
-  createFetchHandlerOpenAPI,
-  createFetchHandlerTRPC,
-} from '../handlers'
+import {createFetchHandlerOpenAPI, createFetchHandlerTRPC} from '../handlers'
 import type {AppRouter} from '../routers'
 
 const db = initDbPGLite()
@@ -109,9 +106,7 @@ describe('openapi route', () => {
 
 describe('trpc route', () => {
   test('query health', async () => {
-    const res = await app.handle(
-      new Request('http://localhost/v1/trpc/health'),
-    )
+    const res = await app.handle(new Request('http://localhost/v1/trpc/health'))
     expect(await res.json()).toMatchObject({result: {data: {ok: true}}})
   })
 
@@ -130,9 +125,7 @@ describe('trpc route', () => {
 
   test('query health bypass elysia', async () => {
     const handler = createFetchHandlerTRPC({endpoint: '/v1/trpc', db})
-    const res = await handler(
-      new Request('http://localhost/v1/trpc/health'),
-    )
+    const res = await handler(new Request('http://localhost/v1/trpc/health'))
     expect(await res.json()).toMatchObject({result: {data: {ok: true}}})
   })
 

--- a/packages/api-v1/routers/connect.ts
+++ b/packages/api-v1/routers/connect.ts
@@ -119,7 +119,6 @@ export const connectRouter = router({
         enabled: false, // tuple type not supported by openAPI
         method: 'POST',
         path: '/connect/post-connect',
-        enabled: false,
       },
     })
     .input(

--- a/packages/api-v1/routers/connect.ts
+++ b/packages/api-v1/routers/connect.ts
@@ -16,6 +16,7 @@ export const connectRouter = router({
       openapi: {
         method: 'POST',
         path: '/connect/pre-connect',
+        enabled: false,
       },
     })
     .input(
@@ -118,6 +119,7 @@ export const connectRouter = router({
         enabled: false, // tuple type not supported by openAPI
         method: 'POST',
         path: '/connect/post-connect',
+        enabled: false,
       },
     })
     .input(

--- a/packages/api-v1/routers/connection.ts
+++ b/packages/api-v1/routers/connection.ts
@@ -410,6 +410,8 @@ export const connectionRouter = router({
       openapi: {
         method: 'DELETE',
         path: '/connection/{id}',
+        description: 'Delete a connection',
+        summary: 'Delete Connection',
       },
     })
     .input(z.object({id: zConnectionId}))
@@ -436,6 +438,7 @@ export const connectionRouter = router({
       openapi: {
         method: 'POST',
         path: '/connection',
+        summary: 'Create Connection',
         description: 'Import an existing connection after validation',
       },
     })

--- a/packages/api-v1/routers/connector.ts
+++ b/packages/api-v1/routers/connector.ts
@@ -41,8 +41,9 @@ export const connectorRouter = router({
       openapi: {
         method: 'GET',
         path: '/connector',
-        description: 'List all connectors with optional filtering',
-        summary: 'List all connectors',
+        description:
+          'List all connectors to understand what integrations are available to configure',
+        summary: 'List Connectors',
       },
     })
     .input(
@@ -50,7 +51,7 @@ export const connectorRouter = router({
         .object({
           expand: z
             .string()
-            .transform((val) => val.split(',').map(s => s.trim()))
+            .transform((val) => val.split(',').map((s) => s.trim()))
             .refine(
               (items) =>
                 items.every((item) => zExpandOptions.safeParse(item).success),

--- a/packages/api-v1/routers/customer.ts
+++ b/packages/api-v1/routers/customer.ts
@@ -196,6 +196,7 @@ export const customerRouter = router({
         path: '/customers',
         description: 'List all customers',
         summary: 'List Customers',
+        enabled: false,
       },
     })
     .input(

--- a/packages/api-v1/routers/general.ts
+++ b/packages/api-v1/routers/general.ts
@@ -9,7 +9,10 @@ export const generalRouter = router({
         path: '/health',
         description: 'Check if the API is operational',
         summary: 'Health Check',
-        enabled: false,
+        // Normally these would be disabled as they are internal endpoints but
+        // since we use them for tests of oas generation we leave them on
+        // and then hardcode remove it form docs in generateDocsOas.bin.cjs
+        // enabled: false,
       },
     })
     .input(z.void())
@@ -17,7 +20,11 @@ export const generalRouter = router({
     .query(() => ({ok: true})),
 
   healthEcho: publicProcedure
-    .meta({openapi: {method: 'POST', path: '/health', enabled: false}})
+    // Normally these would be disabled as they are internal endpoints but
+    // since we use them for tests of oas generation we leave them on
+    // and then hardcode remove it form docs in generateDocsOas.bin.cjs
+    // enabled: false,
+    .meta({openapi: {method: 'POST', path: '/health'}})
     .input(z.object({}).passthrough())
     .output(z.object({}).passthrough())
     .mutation(({input}) => ({input})),

--- a/packages/api-v1/routers/general.ts
+++ b/packages/api-v1/routers/general.ts
@@ -9,6 +9,7 @@ export const generalRouter = router({
         path: '/health',
         description: 'Check if the API is operational',
         summary: 'Health Check',
+        enabled: false,
       },
     })
     .input(z.void())
@@ -16,7 +17,7 @@ export const generalRouter = router({
     .query(() => ({ok: true})),
 
   healthEcho: publicProcedure
-    .meta({openapi: {method: 'POST', path: '/health'}})
+    .meta({openapi: {method: 'POST', path: '/health', enabled: false}})
     .input(z.object({}).passthrough())
     .output(z.object({}).passthrough())
     .mutation(({input}) => ({input})),
@@ -28,6 +29,7 @@ export const generalRouter = router({
         path: '/viewer',
         description: 'Get information about the current authenticated user',
         summary: 'Get Current User',
+        enabled: false,
       },
     })
     .input(z.void())

--- a/packages/api-v1/routers/general.ts
+++ b/packages/api-v1/routers/general.ts
@@ -36,7 +36,10 @@ export const generalRouter = router({
         path: '/viewer',
         description: 'Get information about the current authenticated user',
         summary: 'Get Current User',
-        enabled: false,
+        // Normally these would be disabled as they are internal endpoints but
+        // since we use them for tests of oas generation we leave them on
+        // and then hardcode remove it form docs in generateDocsOas.bin.cjs
+        // enabled: false,
       },
     })
     .input(z.void())

--- a/packages/api-v1/trpc/_base.ts
+++ b/packages/api-v1/trpc/_base.ts
@@ -3,16 +3,8 @@ import {type OpenApiMeta} from 'trpc-to-openapi'
 import {hasRole, type Viewer} from '@openint/cdk'
 import type {RouterContext} from './context'
 
-export interface RouterMeta extends OpenApiMeta {
-  /**
-   * Indicate whether this is an internal API and
-   * should therefore not be generated as part of the OpenAPI spec
-   */
-  internal?: boolean
-}
-
 export const trpc = initTRPC
-  .meta<RouterMeta>()
+  .meta<OpenApiMeta>()
   .context<RouterContext>()
   .create({allowOutsideOfServer: true})
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR hides private APIs by disabling specific endpoints and removing their OpenAPI schema definitions.
> 
>   - **Behavior**:
>     - Disables `/connect/pre-connect` and `/customers` endpoints in `connectRouter` and `customerRouter` respectively.
>     - Removes OpenAPI schema definitions for private APIs in `openapi.json` and `openapi.types.ts`.
>   - **OpenAPI**:
>     - Removes `preConnect` and `listCustomers` operations from `openapi.json` and `openapi.types.ts`.
>     - Removes related schema definitions for connectors in `openapi.json` and `openapi.types.ts`.
>   - **Misc**:
>     - Updates `release-workflow.yml` to change `deployment-url` for Vercel.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 69052fd64c0d2610fd821c02f9085ce9961a7726. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->