### PR TITLE
feat(devexp): making request body optional

### DIFF
--- a/docs/mintlify.oas.yml
+++ b/docs/mintlify.oas.yml
@@ -1404,7 +1404,7 @@ paths:
             description: The id of the customer in your application. Ensure it is unique for that customer.
           required: true
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -2324,7 +2324,7 @@
           }
         ],
         "requestBody": {
-          "required": true,
+          "required": false,
           "content": {
             "application/json": {
               "schema": {

--- a/packages/api-v1/__generated__/openapi.types.ts
+++ b/packages/api-v1/__generated__/openapi.types.ts
@@ -3569,7 +3569,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody: {
+        requestBody?: {
             content: {
                 "application/json": {
                     /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make request body optional for `/customer/{customer_id}/magic-link` and `/customer/{customer_id}/token`, with error handling for missing `customer_id`.
> 
>   - **Behavior**:
>     - Request body for `/customer/{customer_id}/magic-link` and `/customer/{customer_id}/token` is now optional in `mintlify.oas.yml` and `openapi.json`.
>     - If `customer_id` is missing in requests, a `BAD_REQUEST` error is thrown in `customerRouter`.
>   - **Code Changes**:
>     - Updated `customerRouter` to handle optional input using `.nullish()` for `getMagicLink` and `createToken`.
>     - Added checks for `customer_id` in `getMagicLink` and `createToken` to throw `TRPCError` if missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 9273670a594e10c1931aa74723f4b8003acc12b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->