### PR TITLE
Handle multiselect fields for plaid

### DIFF
--- a/apps/web/app/console/(authenticated)/connector-config/client.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/client.tsx
@@ -47,12 +47,15 @@ export function ConnectorConfigList(props: {
   )
   const connectorRes = useSuspenseQuery(
     trpc.listConnectors.queryOptions(
-      {},
+      {
+        expand: ['schemas'],
+      },
       initialConnectorData ? {initialData: initialConnectorData} : undefined,
     ),
   )
 
   const connectorConfigs = res.data.items
+
   const formSchema = {
     type: 'object' as const,
     properties: {

--- a/apps/web/app/console/(authenticated)/connector-config/page.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/page.tsx
@@ -34,7 +34,9 @@ export default async function Page(props: PageProps) {
                 offset: number
               }
             }
-            initialConnectorData={await api.listConnectors()}
+            initialConnectorData={await api.listConnectors({
+              expand: ['schemas'],
+            })}
           />
         </Suspense>
       </ClientApp>

--- a/connectors/connector-plaid/def.ts
+++ b/connectors/connector-plaid/def.ts
@@ -37,10 +37,15 @@ export const plaidSchemas = {
         Maximum length of 30 characters.
         If a value longer than 30 characters is provided, Link will display "This Application" instead.`,
       ),
-    products: z.array(zProducts).default([Products.Transactions]),
+    products: z.array(zProducts).default([Products.Transactions]).openapi({
+      'ui:field': 'MultiSelectField',
+    }),
     countryCodes: z
       .array(zCountryCode)
-      .default([CountryCode.Us, CountryCode.Ca]),
+      .default([CountryCode.Us, CountryCode.Ca])
+      .openapi({
+        'ui:field': 'MultiSelectField',
+      }),
     /**
      * When using a Link customization, the language configured
      * here must match the setting in the customization, or the customization will not be applied.

--- a/connectors/connector-plaid/def.ts
+++ b/connectors/connector-plaid/def.ts
@@ -27,7 +27,11 @@ export const plaidSchemas = {
           })
           .openapi({title: 'Use my own'}),
       ])
-      .optional(),
+      .optional()
+      .openapi({
+        'ui:field': 'CredentialsField',
+        'ui:fieldReplacesAnyOrOneOf': true,
+      }),
     clientName: z
       .string()
       .max(30)

--- a/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
+++ b/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
@@ -2295,62 +2295,35 @@ exports[`db: pglite list connectors with schemas 1`] = `
       "connector_config": {
         "properties": {
           "oauth": {
-            "anyOf": [
-              {
-                "properties": {
-                  "scopes": {
-                    "description": "Scopes for OpenInt Platform Credentials",
-                    "items": {
-                      "enum": [
-                        "https://www.googleapis.com/auth/drive.file",
-                      ],
-                      "type": "string",
-                    },
-                    "title": "Scopes",
-                    "type": "array",
-                  },
-                },
-                "required": [
-                  "scopes",
-                ],
-                "title": "Use OpenInt platform credentials",
-                "type": "object",
-              },
-              {
-                "description": "Base oauth configuration for the connector",
-                "properties": {
-                  "client_id": {
-                    "type": [
-                      "string",
-                      "null",
-                    ],
-                  },
-                  "client_secret": {
-                    "type": [
-                      "string",
-                      "null",
-                    ],
-                  },
-                  "scopes": {
-                    "items": {
-                      "type": "string",
-                    },
-                    "type": [
-                      "array",
-                      "null",
-                    ],
-                  },
-                },
-                "title": "Use my own",
+            "description": "Base oauth configuration for the connector",
+            "properties": {
+              "client_id": {
                 "type": [
-                  "object",
+                  "string",
                   "null",
                 ],
-                "ui:field": "OAuthField",
               },
+              "client_secret": {
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "scopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": [
+                  "array",
+                  "null",
+                ],
+              },
+            },
+            "type": [
+              "object",
+              "null",
             ],
             "ui:field": "OAuthField",
-            "ui:fieldReplacesAnyOrOneOf": true,
           },
         },
         "required": [

--- a/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
+++ b/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
@@ -2295,35 +2295,62 @@ exports[`db: pglite list connectors with schemas 1`] = `
       "connector_config": {
         "properties": {
           "oauth": {
-            "description": "Base oauth configuration for the connector",
-            "properties": {
-              "client_id": {
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
-              "client_secret": {
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
-              "scopes": {
-                "items": {
-                  "type": "string",
+            "anyOf": [
+              {
+                "properties": {
+                  "scopes": {
+                    "description": "Scopes for OpenInt Platform Credentials",
+                    "items": {
+                      "enum": [
+                        "https://www.googleapis.com/auth/drive.file",
+                      ],
+                      "type": "string",
+                    },
+                    "title": "Scopes",
+                    "type": "array",
+                  },
                 },
+                "required": [
+                  "scopes",
+                ],
+                "title": "Use OpenInt platform credentials",
+                "type": "object",
+              },
+              {
+                "description": "Base oauth configuration for the connector",
+                "properties": {
+                  "client_id": {
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "client_secret": {
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "scopes": {
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": [
+                      "array",
+                      "null",
+                    ],
+                  },
+                },
+                "title": "Use my own",
                 "type": [
-                  "array",
+                  "object",
                   "null",
                 ],
+                "ui:field": "OAuthField",
               },
-            },
-            "type": [
-              "object",
-              "null",
             ],
             "ui:field": "OAuthField",
+            "ui:fieldReplacesAnyOrOneOf": true,
           },
         },
         "required": [
@@ -5766,6 +5793,7 @@ exports[`db: pglite list connectors with schemas 1`] = `
               "type": "string",
             },
             "type": "array",
+            "ui:field": "MultiSelectField",
           },
           "credentials": {
             "anyOf": [
@@ -5790,6 +5818,8 @@ exports[`db: pglite list connectors with schemas 1`] = `
                 "type": "object",
               },
             ],
+            "ui:field": "CredentialsField",
+            "ui:fieldReplacesAnyOrOneOf": true,
           },
           "envName": {
             "enum": [
@@ -5837,6 +5867,7 @@ exports[`db: pglite list connectors with schemas 1`] = `
               "type": "string",
             },
             "type": "array",
+            "ui:field": "MultiSelectField",
           },
         },
         "required": [

--- a/packages/ui-v1/components/MultiSelect.stories.tsx
+++ b/packages/ui-v1/components/MultiSelect.stories.tsx
@@ -1,0 +1,64 @@
+import type {Meta, StoryObj} from '@storybook/react'
+import React from 'react'
+import {MultiSelect} from './MultiSelect'
+
+const meta: Meta<typeof MultiSelect> = {
+  title: 'Components/MultiSelect',
+  component: MultiSelect,
+  argTypes: {},
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const items = [
+  'recents',
+  'home',
+  'applications',
+  'desktop',
+  'downloads',
+  'documents',
+  'pictures',
+  'videos',
+  'music',
+  'cloud',
+  'favorites',
+  'shared',
+  'trash',
+  'archives',
+  'projects',
+  'work',
+  'personal',
+  'templates',
+  'backups',
+  'scripts',
+  'code',
+  'design',
+  'notes',
+  'presentations',
+  'spreadsheets',
+  'databases',
+  'external',
+  'network',
+  'system',
+  'utilities',
+]
+
+const MultiSelectWithState = () => {
+  const [selected, setSelected] = React.useState<string[]>([])
+
+  return (
+    <MultiSelect
+      value={selected}
+      onChange={(newValue) => {
+        console.log('Selected values:', newValue)
+        setSelected(newValue)
+      }}
+      items={items}
+    />
+  )
+}
+
+export const Default: Story = {
+  render: () => <MultiSelectWithState />,
+}

--- a/packages/ui-v1/components/MultiSelect.tsx
+++ b/packages/ui-v1/components/MultiSelect.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import {useState} from 'react'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Checkbox,
+  Input,
+  Separator,
+} from '@openint/shadcn/ui'
+
+interface MultiSelectProps {
+  items: string[]
+  onChange: (value: string[]) => void
+  value: string[]
+  hideSearch?: boolean
+}
+
+export function MultiSelect({
+  hideSearch = false,
+  items,
+  value,
+  onChange,
+}: MultiSelectProps) {
+  const [search, setSearch] = useState('')
+
+  const filteredItems =
+    search !== ''
+      ? items.filter((item) =>
+          item.toLowerCase().includes(search.toLowerCase()),
+        )
+      : items
+
+  return (
+    <Card className="w-full max-w-md gap-0 rounded-sm pb-0">
+      {!hideSearch && (
+        <>
+          <CardHeader>
+            <Input
+              placeholder="Search..."
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value)
+              }}
+              className="mb-4 w-full"
+            />
+          </CardHeader>
+          <Separator />
+        </>
+      )}
+      <CardContent className="overflow-y-auto">
+        <div className="flex flex-col gap-3">
+          <div className="max-h-[300px]">
+            {filteredItems.map((item) => (
+              <label
+                key={item}
+                className="flex cursor-pointer items-center space-x-2 py-1">
+                <Checkbox
+                  checked={value.includes(item)}
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      onChange([...value, item])
+                    } else {
+                      onChange(value.filter((value) => value !== item))
+                    }
+                  }}
+                  className="mr-2"
+                />
+                <span>{item}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -5,6 +5,7 @@ import {Input, Switch} from '@openint/shadcn/ui'
 import {ConnectorBadges} from '../../domain-components/ConnectorCard'
 import ConnectorScopes from '../ConnectorScopes'
 import {CopyID} from '../CopyID'
+import {CredentialsField} from './fields/CredentialsField'
 import {MultiSelectField} from './fields/MultiSelectField'
 
 interface OAuthFormData {
@@ -215,6 +216,7 @@ export const fields = {
   OAuthField,
   DisabledField,
   MultiSelectField,
+  CredentialsField,
   // Default fields we can override
   // - ArrayField
   // - ArraySchemaField

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -5,6 +5,7 @@ import {Input, Switch} from '@openint/shadcn/ui'
 import {ConnectorBadges} from '../../domain-components/ConnectorCard'
 import ConnectorScopes from '../ConnectorScopes'
 import {CopyID} from '../CopyID'
+import {MultiSelectField} from './fields/MultiSelectField'
 
 interface OAuthFormData {
   client_id?: string
@@ -213,6 +214,7 @@ export function DisabledField(props: FieldProps<boolean>) {
 export const fields = {
   OAuthField,
   DisabledField,
+  MultiSelectField,
   // Default fields we can override
   // - ArrayField
   // - ArraySchemaField

--- a/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
@@ -1,0 +1,100 @@
+import type {FieldProps} from '@rjsf/utils'
+import {useState} from 'react'
+import type {ConnectorConfig} from '@openint/api-v1/models'
+import {Input} from '@openint/shadcn/ui/input'
+import {Switch} from '@openint/shadcn/ui/switch'
+
+type Credentials = {
+  clientId: string
+  clientSecret: string
+} | null
+
+interface CredentialsFormContext {
+  connectorName: string
+  initialData: ConnectorConfig
+}
+
+/**
+ * This field is used to handle credentials for plaid connector
+ */
+export function CredentialsField<T extends Credentials = Credentials>(
+  props: FieldProps<T>,
+) {
+  const {formData, onChange, formContext} = props
+  const {connectorName, initialData} = formContext as CredentialsFormContext
+  const [useOpenIntCredentials, setUseOpenIntCredentials] = useState(
+    !formData?.clientId && !formData?.clientSecret,
+  )
+
+  console.log({initialData, formData})
+
+  const handleChange = (field: string, value?: string | string[]) => {
+    onChange({
+      ...formData,
+      [field]: value,
+    } as T)
+  }
+
+  const handleSwitchChange = (newValue: boolean) => {
+    console.log('handleSwitchChange', newValue)
+    if (newValue) {
+      onChange(null as T)
+    } else {
+      if (initialData.config.credentials) {
+        onChange({
+          clientId: initialData.config.credentials.clientId,
+          clientSecret: initialData.config.credentials.clientSecret,
+        } as T)
+      }
+    }
+    setUseOpenIntCredentials(newValue)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <label htmlFor="use-openint-credentials" className="font-bold">
+          Use OpenInt {connectorName} credentials
+        </label>
+        <Switch
+          id="use-openint-credentials"
+          checked={useOpenIntCredentials}
+          onCheckedChange={handleSwitchChange}
+        />
+      </div>
+
+      {!useOpenIntCredentials && (
+        <div className="space-y-2">
+          <label
+            htmlFor="client-id"
+            className="text-sm font-medium text-gray-700">
+            Client ID
+          </label>
+          <Input
+            id="client-id"
+            type="text"
+            value={formData?.clientId || ''}
+            onChange={(e) => {
+              handleChange('clientId', e.target.value)
+            }}
+            placeholder="Enter client ID"
+          />
+          <label
+            htmlFor="client-secret"
+            className="text-sm font-medium text-gray-700">
+            Client Secret
+          </label>
+          <Input
+            id="client-secret"
+            type="text"
+            value={formData?.clientSecret || ''}
+            onChange={(e) => {
+              handleChange('clientSecret', e.target.value)
+            }}
+            placeholder="Enter client secret"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
@@ -2,6 +2,7 @@ import type {FieldProps} from '@rjsf/utils'
 import {useState} from 'react'
 import type {ConnectorConfig} from '@openint/api-v1/models'
 import {Input} from '@openint/shadcn/ui/input'
+import {Label} from '@openint/shadcn/ui/label'
 import {Switch} from '@openint/shadcn/ui/switch'
 
 type Credentials = {
@@ -53,11 +54,8 @@ export function CredentialsField<T extends Credentials = Credentials>(
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <label htmlFor="use-openint-credentials" className="font-bold">
-          Use OpenInt {connectorName} credentials
-        </label>
+        <Label>Use OpenInt {connectorName} credentials</Label>
         <Switch
-          id="use-openint-credentials"
           checked={useOpenIntCredentials}
           onCheckedChange={handleSwitchChange}
         />
@@ -65,13 +63,8 @@ export function CredentialsField<T extends Credentials = Credentials>(
 
       {!useOpenIntCredentials && (
         <div className="space-y-2">
-          <label
-            htmlFor="client-id"
-            className="text-sm font-medium text-gray-700">
-            Client ID
-          </label>
+          <Label>Client ID</Label>
           <Input
-            id="client-id"
             type="text"
             value={formData?.clientId || ''}
             onChange={(e) => {

--- a/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
@@ -27,8 +27,6 @@ export function CredentialsField<T extends Credentials = Credentials>(
     !formData?.clientId && !formData?.clientSecret,
   )
 
-  console.log({initialData, formData})
-
   const handleChange = (field: string, value?: string | string[]) => {
     onChange({
       ...formData,

--- a/packages/ui-v1/components/schema-form/fields/MultiSelectField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/MultiSelectField.tsx
@@ -1,0 +1,39 @@
+import type {FieldProps} from '@rjsf/utils'
+import {MultiSelect} from '../../MultiSelect'
+
+interface Schema {
+  type: string
+  items: {
+    enum: string[]
+  }
+  default?: string[]
+}
+
+const getValueByName = (name: string): string =>
+  name
+    .replace(/([A-Z])/g, ' $1')
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+export function MultiSelectField<T extends string[] = string[]>(
+  props: FieldProps<T>,
+) {
+  const {onChange, formData} = props
+  const {items, default: defaultValue = []} = props.schema as Schema
+
+  const handleChange = (newValue: string[]) => {
+    onChange(newValue as T)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="font-bold">{getValueByName(props.name)}</h3>
+      <MultiSelect
+        items={items.enum ?? []}
+        onChange={handleChange}
+        value={formData ?? defaultValue}
+      />
+    </div>
+  )
+}

--- a/packages/ui-v1/components/schema-form/fields/MultiSelectField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/MultiSelectField.tsx
@@ -9,7 +9,7 @@ interface Schema {
   default?: string[]
 }
 
-const getValueByName = (name: string): string =>
+const camelCaseToFieldName = (name: string): string =>
   name
     .replace(/([A-Z])/g, ' $1')
     .split(' ')
@@ -28,7 +28,7 @@ export function MultiSelectField<T extends string[] = string[]>(
 
   return (
     <div className="flex flex-col gap-2">
-      <h3 className="font-bold">{getValueByName(props.name)}</h3>
+      <h3 className="font-bold">{camelCaseToFieldName(props.name)}</h3>
       <MultiSelect
         items={items.enum ?? []}
         onChange={handleChange}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add multiselect field support for Plaid connector configuration with new UI components and schema updates.
> 
>   - **UI Components**:
>     - Add `MultiSelect` component in `MultiSelect.tsx` for handling multiselect UI with optional search functionality.
>     - Add `MultiSelectField` in `fields/MultiSelectField.tsx` to integrate `MultiSelect` into schema forms.
>     - Add `CredentialsField` in `fields/CredentialsField.tsx` for handling Plaid credentials with a toggle for OpenInt credentials.
>   - **Schema Updates**:
>     - Update `plaidSchemas` in `def.ts` to use `MultiSelectField` for `products` and `countryCodes`.
>     - Add `ui:field` properties to support new fields in `def.ts`.
>   - **Data Fetching**:
>     - Modify `listConnectors` and `listConnectorConfigs` queries in `client.tsx` and `page.tsx` to expand schemas.
>   - **Testing**:
>     - Add `MultiSelect.stories.tsx` for Storybook testing of `MultiSelect` component.
>   - **Snapshots**:
>     - Update `connector.spec.ts.snap` to reflect schema changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 8f5909ca1e79458a7798e227beed0a105cd78d0a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->