### PR TITLE
feat(connectors): renaming dummyoauth2 to acmeoauth2

### DIFF
--- a/connectors/all-connectors/connectors.meta.ts
+++ b/connectors/all-connectors/connectors.meta.ts
@@ -1,6 +1,18 @@
 // generated file. Do not modify by hand
 
 export default {
+  'acme-oauth2': {
+    hasClient: false,
+    hasServer: false,
+    metadata: {
+      displayName: 'Acme Oauth2',
+      stage: 'ga',
+      verticals: ['social-media'],
+      logoUrl:
+        'https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-acme-oauth2.svg',
+      authType: 'OAUTH2',
+    },
+  },
   aircall: {
     hasClient: false,
     hasServer: false,
@@ -70,18 +82,6 @@ export default {
       verticals: ['social-media'],
       logoUrl:
         'https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-discord.svg',
-      authType: 'OAUTH2',
-    },
-  },
-  'dummy-oauth2': {
-    hasClient: false,
-    hasServer: false,
-    metadata: {
-      displayName: 'Dummy OAuth2',
-      stage: 'ga',
-      verticals: ['social-media'],
-      logoUrl:
-        'https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-dummy-oauth2.svg',
       authType: 'OAUTH2',
     },
   },

--- a/connectors/cnext/json-defs.ts
+++ b/connectors/cnext/json-defs.ts
@@ -3,7 +3,7 @@
 import aircall from './json-defs/aircall'
 import confluence from './json-defs/confluence'
 import discord from './json-defs/discord'
-import dummy_oauth2 from './json-defs/dummy-oauth2'
+import acme_oauth2 from './json-defs/acme-oauth2'
 import github from './json-defs/github'
 import googlecalendar from './json-defs/googlecalendar'
 import googledocs from './json-defs/googledocs'
@@ -20,7 +20,7 @@ import sharepointonline from './json-defs/sharepointonline'
 import slack from './json-defs/slack'
 
 const defs = {
-  'dummy-oauth2': dummy_oauth2,
+  'acme-oauth2': acme_oauth2,
   sharepointonline,
   slack,
   github,

--- a/connectors/cnext/json-defs/acme-oauth2.ts
+++ b/connectors/cnext/json-defs/acme-oauth2.ts
@@ -3,14 +3,14 @@ import type {JsonConnectorDef} from '../schema'
 export default {
   audience: ['consumer'],
   verticals: ['social-media'],
-  display_name: 'Dummy OAuth2',
+  display_name: 'Acme Oauth2',
   stage: 'ga',
   version: 1,
   auth: {
     type: 'OAUTH2',
     code_challenge_method: 'S256',
-    authorization_request_url: '{{baseURLs.api}}/dummy-oauth2/authorize',
-    token_request_url: '{{baseURLs.api}}/dummy-oauth2/token',
+    authorization_request_url: '{{baseURLs.api}}/acme-oauth2/authorize',
+    token_request_url: '{{baseURLs.api}}/acme-oauth2/token',
     scope_separator: ' ',
     params_config: {},
     openint_scopes: ['read:profile'],

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -265,7 +265,7 @@
                           {
                             "oneOf": [
                               {
-                                "$ref": "#/components/schemas/connector.dummy-oauth2.discriminated_connector_config"
+                                "$ref": "#/components/schemas/connector.acme-oauth2.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.sharepointonline.discriminated_connector_config"
@@ -331,9 +331,6 @@
                                 "$ref": "#/components/schemas/connector.coda.discriminated_connector_config"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.facebook.discriminated_connector_config"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.finch.discriminated_connector_config"
                               },
                               {
@@ -343,28 +340,10 @@
                                 "$ref": "#/components/schemas/connector.foreceipt.discriminated_connector_config"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.gong.discriminated_connector_config"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.greenhouse.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.heron.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.instagram.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.intercom.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.jira.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.kustomer.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.lever.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.lunchmoney.discriminated_connector_config"
@@ -376,19 +355,10 @@
                                 "$ref": "#/components/schemas/connector.merge.discriminated_connector_config"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.microsoft.discriminated_connector_config"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.moota.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.onebrick.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.outreach.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.pipedrive.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.plaid.discriminated_connector_config"
@@ -398,12 +368,6 @@
                               },
                               {
                                 "$ref": "#/components/schemas/connector.ramp.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.reddit.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.salesloft.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.saltedge.discriminated_connector_config"
@@ -424,28 +388,19 @@
                                 "$ref": "#/components/schemas/connector.twenty.discriminated_connector_config"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.twitter.discriminated_connector_config"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.venmo.discriminated_connector_config"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.wise.discriminated_connector_config"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.xero.discriminated_connector_config"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.yodlee.discriminated_connector_config"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.zohodesk.discriminated_connector_config"
                               }
                             ],
                             "discriminator": {
                               "propertyName": "connector_name",
                               "mapping": {
-                                "dummy-oauth2": "#/components/schemas/connector.dummy-oauth2.discriminated_connector_config",
+                                "acme-oauth2": "#/components/schemas/connector.acme-oauth2.discriminated_connector_config",
                                 "sharepointonline": "#/components/schemas/connector.sharepointonline.discriminated_connector_config",
                                 "slack": "#/components/schemas/connector.slack.discriminated_connector_config",
                                 "github": "#/components/schemas/connector.github.discriminated_connector_config",
@@ -467,43 +422,28 @@
                                 "apollo": "#/components/schemas/connector.apollo.discriminated_connector_config",
                                 "brex": "#/components/schemas/connector.brex.discriminated_connector_config",
                                 "coda": "#/components/schemas/connector.coda.discriminated_connector_config",
-                                "facebook": "#/components/schemas/connector.facebook.discriminated_connector_config",
                                 "finch": "#/components/schemas/connector.finch.discriminated_connector_config",
                                 "firebase": "#/components/schemas/connector.firebase.discriminated_connector_config",
                                 "foreceipt": "#/components/schemas/connector.foreceipt.discriminated_connector_config",
-                                "gong": "#/components/schemas/connector.gong.discriminated_connector_config",
                                 "greenhouse": "#/components/schemas/connector.greenhouse.discriminated_connector_config",
                                 "heron": "#/components/schemas/connector.heron.discriminated_connector_config",
-                                "instagram": "#/components/schemas/connector.instagram.discriminated_connector_config",
-                                "intercom": "#/components/schemas/connector.intercom.discriminated_connector_config",
-                                "jira": "#/components/schemas/connector.jira.discriminated_connector_config",
-                                "kustomer": "#/components/schemas/connector.kustomer.discriminated_connector_config",
-                                "lever": "#/components/schemas/connector.lever.discriminated_connector_config",
                                 "lunchmoney": "#/components/schemas/connector.lunchmoney.discriminated_connector_config",
                                 "mercury": "#/components/schemas/connector.mercury.discriminated_connector_config",
                                 "merge": "#/components/schemas/connector.merge.discriminated_connector_config",
-                                "microsoft": "#/components/schemas/connector.microsoft.discriminated_connector_config",
                                 "moota": "#/components/schemas/connector.moota.discriminated_connector_config",
                                 "onebrick": "#/components/schemas/connector.onebrick.discriminated_connector_config",
-                                "outreach": "#/components/schemas/connector.outreach.discriminated_connector_config",
-                                "pipedrive": "#/components/schemas/connector.pipedrive.discriminated_connector_config",
                                 "plaid": "#/components/schemas/connector.plaid.discriminated_connector_config",
                                 "postgres": "#/components/schemas/connector.postgres.discriminated_connector_config",
                                 "ramp": "#/components/schemas/connector.ramp.discriminated_connector_config",
-                                "reddit": "#/components/schemas/connector.reddit.discriminated_connector_config",
-                                "salesloft": "#/components/schemas/connector.salesloft.discriminated_connector_config",
                                 "saltedge": "#/components/schemas/connector.saltedge.discriminated_connector_config",
                                 "splitwise": "#/components/schemas/connector.splitwise.discriminated_connector_config",
                                 "stripe": "#/components/schemas/connector.stripe.discriminated_connector_config",
                                 "teller": "#/components/schemas/connector.teller.discriminated_connector_config",
                                 "toggl": "#/components/schemas/connector.toggl.discriminated_connector_config",
                                 "twenty": "#/components/schemas/connector.twenty.discriminated_connector_config",
-                                "twitter": "#/components/schemas/connector.twitter.discriminated_connector_config",
                                 "venmo": "#/components/schemas/connector.venmo.discriminated_connector_config",
                                 "wise": "#/components/schemas/connector.wise.discriminated_connector_config",
-                                "xero": "#/components/schemas/connector.xero.discriminated_connector_config",
-                                "yodlee": "#/components/schemas/connector.yodlee.discriminated_connector_config",
-                                "zohodesk": "#/components/schemas/connector.zohodesk.discriminated_connector_config"
+                                "yodlee": "#/components/schemas/connector.yodlee.discriminated_connector_config"
                               }
                             },
                             "description": "Connector specific data"
@@ -751,7 +691,7 @@
                     {
                       "oneOf": [
                         {
-                          "$ref": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings"
+                          "$ref": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings"
@@ -817,9 +757,6 @@
                           "$ref": "#/components/schemas/connector.coda.discriminated_connection_settings"
                         },
                         {
-                          "$ref": "#/components/schemas/connector.facebook.discriminated_connection_settings"
-                        },
-                        {
                           "$ref": "#/components/schemas/connector.finch.discriminated_connection_settings"
                         },
                         {
@@ -829,28 +766,10 @@
                           "$ref": "#/components/schemas/connector.foreceipt.discriminated_connection_settings"
                         },
                         {
-                          "$ref": "#/components/schemas/connector.gong.discriminated_connection_settings"
-                        },
-                        {
                           "$ref": "#/components/schemas/connector.greenhouse.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.heron.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.instagram.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.intercom.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.jira.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.kustomer.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.lever.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings"
@@ -862,19 +781,10 @@
                           "$ref": "#/components/schemas/connector.merge.discriminated_connection_settings"
                         },
                         {
-                          "$ref": "#/components/schemas/connector.microsoft.discriminated_connection_settings"
-                        },
-                        {
                           "$ref": "#/components/schemas/connector.moota.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.onebrick.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.outreach.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.pipedrive.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.plaid.discriminated_connection_settings"
@@ -884,12 +794,6 @@
                         },
                         {
                           "$ref": "#/components/schemas/connector.ramp.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.reddit.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.salesloft.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.saltedge.discriminated_connection_settings"
@@ -910,28 +814,19 @@
                           "$ref": "#/components/schemas/connector.twenty.discriminated_connection_settings"
                         },
                         {
-                          "$ref": "#/components/schemas/connector.twitter.discriminated_connection_settings"
-                        },
-                        {
                           "$ref": "#/components/schemas/connector.venmo.discriminated_connection_settings"
                         },
                         {
                           "$ref": "#/components/schemas/connector.wise.discriminated_connection_settings"
                         },
                         {
-                          "$ref": "#/components/schemas/connector.xero.discriminated_connection_settings"
-                        },
-                        {
                           "$ref": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
-                        },
-                        {
-                          "$ref": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
                         }
                       ],
                       "discriminator": {
                         "propertyName": "connector_name",
                         "mapping": {
-                          "dummy-oauth2": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings",
+                          "acme-oauth2": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings",
                           "sharepointonline": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings",
                           "slack": "#/components/schemas/connector.slack.discriminated_connection_settings",
                           "github": "#/components/schemas/connector.github.discriminated_connection_settings",
@@ -953,43 +848,28 @@
                           "apollo": "#/components/schemas/connector.apollo.discriminated_connection_settings",
                           "brex": "#/components/schemas/connector.brex.discriminated_connection_settings",
                           "coda": "#/components/schemas/connector.coda.discriminated_connection_settings",
-                          "facebook": "#/components/schemas/connector.facebook.discriminated_connection_settings",
                           "finch": "#/components/schemas/connector.finch.discriminated_connection_settings",
                           "firebase": "#/components/schemas/connector.firebase.discriminated_connection_settings",
                           "foreceipt": "#/components/schemas/connector.foreceipt.discriminated_connection_settings",
-                          "gong": "#/components/schemas/connector.gong.discriminated_connection_settings",
                           "greenhouse": "#/components/schemas/connector.greenhouse.discriminated_connection_settings",
                           "heron": "#/components/schemas/connector.heron.discriminated_connection_settings",
-                          "instagram": "#/components/schemas/connector.instagram.discriminated_connection_settings",
-                          "intercom": "#/components/schemas/connector.intercom.discriminated_connection_settings",
-                          "jira": "#/components/schemas/connector.jira.discriminated_connection_settings",
-                          "kustomer": "#/components/schemas/connector.kustomer.discriminated_connection_settings",
-                          "lever": "#/components/schemas/connector.lever.discriminated_connection_settings",
                           "lunchmoney": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings",
                           "mercury": "#/components/schemas/connector.mercury.discriminated_connection_settings",
                           "merge": "#/components/schemas/connector.merge.discriminated_connection_settings",
-                          "microsoft": "#/components/schemas/connector.microsoft.discriminated_connection_settings",
                           "moota": "#/components/schemas/connector.moota.discriminated_connection_settings",
                           "onebrick": "#/components/schemas/connector.onebrick.discriminated_connection_settings",
-                          "outreach": "#/components/schemas/connector.outreach.discriminated_connection_settings",
-                          "pipedrive": "#/components/schemas/connector.pipedrive.discriminated_connection_settings",
                           "plaid": "#/components/schemas/connector.plaid.discriminated_connection_settings",
                           "postgres": "#/components/schemas/connector.postgres.discriminated_connection_settings",
                           "ramp": "#/components/schemas/connector.ramp.discriminated_connection_settings",
-                          "reddit": "#/components/schemas/connector.reddit.discriminated_connection_settings",
-                          "salesloft": "#/components/schemas/connector.salesloft.discriminated_connection_settings",
                           "saltedge": "#/components/schemas/connector.saltedge.discriminated_connection_settings",
                           "splitwise": "#/components/schemas/connector.splitwise.discriminated_connection_settings",
                           "stripe": "#/components/schemas/connector.stripe.discriminated_connection_settings",
                           "teller": "#/components/schemas/connector.teller.discriminated_connection_settings",
                           "toggl": "#/components/schemas/connector.toggl.discriminated_connection_settings",
                           "twenty": "#/components/schemas/connector.twenty.discriminated_connection_settings",
-                          "twitter": "#/components/schemas/connector.twitter.discriminated_connection_settings",
                           "venmo": "#/components/schemas/connector.venmo.discriminated_connection_settings",
                           "wise": "#/components/schemas/connector.wise.discriminated_connection_settings",
-                          "xero": "#/components/schemas/connector.xero.discriminated_connection_settings",
-                          "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings",
-                          "zohodesk": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
+                          "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
                         }
                       },
                       "description": "Connector specific data"
@@ -1325,7 +1205,7 @@
                           {
                             "oneOf": [
                               {
-                                "$ref": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings"
+                                "$ref": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings"
@@ -1391,9 +1271,6 @@
                                 "$ref": "#/components/schemas/connector.coda.discriminated_connection_settings"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.facebook.discriminated_connection_settings"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.finch.discriminated_connection_settings"
                               },
                               {
@@ -1403,28 +1280,10 @@
                                 "$ref": "#/components/schemas/connector.foreceipt.discriminated_connection_settings"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.gong.discriminated_connection_settings"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.greenhouse.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.heron.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.instagram.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.intercom.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.jira.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.kustomer.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.lever.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings"
@@ -1436,19 +1295,10 @@
                                 "$ref": "#/components/schemas/connector.merge.discriminated_connection_settings"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.microsoft.discriminated_connection_settings"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.moota.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.onebrick.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.outreach.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.pipedrive.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.plaid.discriminated_connection_settings"
@@ -1458,12 +1308,6 @@
                               },
                               {
                                 "$ref": "#/components/schemas/connector.ramp.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.reddit.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.salesloft.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.saltedge.discriminated_connection_settings"
@@ -1484,28 +1328,19 @@
                                 "$ref": "#/components/schemas/connector.twenty.discriminated_connection_settings"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.twitter.discriminated_connection_settings"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.venmo.discriminated_connection_settings"
                               },
                               {
                                 "$ref": "#/components/schemas/connector.wise.discriminated_connection_settings"
                               },
                               {
-                                "$ref": "#/components/schemas/connector.xero.discriminated_connection_settings"
-                              },
-                              {
                                 "$ref": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
-                              },
-                              {
-                                "$ref": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
                               }
                             ],
                             "discriminator": {
                               "propertyName": "connector_name",
                               "mapping": {
-                                "dummy-oauth2": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings",
+                                "acme-oauth2": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings",
                                 "sharepointonline": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings",
                                 "slack": "#/components/schemas/connector.slack.discriminated_connection_settings",
                                 "github": "#/components/schemas/connector.github.discriminated_connection_settings",
@@ -1527,43 +1362,28 @@
                                 "apollo": "#/components/schemas/connector.apollo.discriminated_connection_settings",
                                 "brex": "#/components/schemas/connector.brex.discriminated_connection_settings",
                                 "coda": "#/components/schemas/connector.coda.discriminated_connection_settings",
-                                "facebook": "#/components/schemas/connector.facebook.discriminated_connection_settings",
                                 "finch": "#/components/schemas/connector.finch.discriminated_connection_settings",
                                 "firebase": "#/components/schemas/connector.firebase.discriminated_connection_settings",
                                 "foreceipt": "#/components/schemas/connector.foreceipt.discriminated_connection_settings",
-                                "gong": "#/components/schemas/connector.gong.discriminated_connection_settings",
                                 "greenhouse": "#/components/schemas/connector.greenhouse.discriminated_connection_settings",
                                 "heron": "#/components/schemas/connector.heron.discriminated_connection_settings",
-                                "instagram": "#/components/schemas/connector.instagram.discriminated_connection_settings",
-                                "intercom": "#/components/schemas/connector.intercom.discriminated_connection_settings",
-                                "jira": "#/components/schemas/connector.jira.discriminated_connection_settings",
-                                "kustomer": "#/components/schemas/connector.kustomer.discriminated_connection_settings",
-                                "lever": "#/components/schemas/connector.lever.discriminated_connection_settings",
                                 "lunchmoney": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings",
                                 "mercury": "#/components/schemas/connector.mercury.discriminated_connection_settings",
                                 "merge": "#/components/schemas/connector.merge.discriminated_connection_settings",
-                                "microsoft": "#/components/schemas/connector.microsoft.discriminated_connection_settings",
                                 "moota": "#/components/schemas/connector.moota.discriminated_connection_settings",
                                 "onebrick": "#/components/schemas/connector.onebrick.discriminated_connection_settings",
-                                "outreach": "#/components/schemas/connector.outreach.discriminated_connection_settings",
-                                "pipedrive": "#/components/schemas/connector.pipedrive.discriminated_connection_settings",
                                 "plaid": "#/components/schemas/connector.plaid.discriminated_connection_settings",
                                 "postgres": "#/components/schemas/connector.postgres.discriminated_connection_settings",
                                 "ramp": "#/components/schemas/connector.ramp.discriminated_connection_settings",
-                                "reddit": "#/components/schemas/connector.reddit.discriminated_connection_settings",
-                                "salesloft": "#/components/schemas/connector.salesloft.discriminated_connection_settings",
                                 "saltedge": "#/components/schemas/connector.saltedge.discriminated_connection_settings",
                                 "splitwise": "#/components/schemas/connector.splitwise.discriminated_connection_settings",
                                 "stripe": "#/components/schemas/connector.stripe.discriminated_connection_settings",
                                 "teller": "#/components/schemas/connector.teller.discriminated_connection_settings",
                                 "toggl": "#/components/schemas/connector.toggl.discriminated_connection_settings",
                                 "twenty": "#/components/schemas/connector.twenty.discriminated_connection_settings",
-                                "twitter": "#/components/schemas/connector.twitter.discriminated_connection_settings",
                                 "venmo": "#/components/schemas/connector.venmo.discriminated_connection_settings",
                                 "wise": "#/components/schemas/connector.wise.discriminated_connection_settings",
-                                "xero": "#/components/schemas/connector.xero.discriminated_connection_settings",
-                                "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings",
-                                "zohodesk": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
+                                "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
                               }
                             },
                             "description": "Connector specific data"
@@ -1697,7 +1517,7 @@
                   "data": {
                     "oneOf": [
                       {
-                        "$ref": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings"
+                        "$ref": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings"
@@ -1763,9 +1583,6 @@
                         "$ref": "#/components/schemas/connector.coda.discriminated_connection_settings"
                       },
                       {
-                        "$ref": "#/components/schemas/connector.facebook.discriminated_connection_settings"
-                      },
-                      {
                         "$ref": "#/components/schemas/connector.finch.discriminated_connection_settings"
                       },
                       {
@@ -1775,28 +1592,10 @@
                         "$ref": "#/components/schemas/connector.foreceipt.discriminated_connection_settings"
                       },
                       {
-                        "$ref": "#/components/schemas/connector.gong.discriminated_connection_settings"
-                      },
-                      {
                         "$ref": "#/components/schemas/connector.greenhouse.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.heron.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.instagram.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.intercom.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.jira.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.kustomer.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.lever.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings"
@@ -1808,19 +1607,10 @@
                         "$ref": "#/components/schemas/connector.merge.discriminated_connection_settings"
                       },
                       {
-                        "$ref": "#/components/schemas/connector.microsoft.discriminated_connection_settings"
-                      },
-                      {
                         "$ref": "#/components/schemas/connector.moota.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.onebrick.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.outreach.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.pipedrive.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.plaid.discriminated_connection_settings"
@@ -1830,12 +1620,6 @@
                       },
                       {
                         "$ref": "#/components/schemas/connector.ramp.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.reddit.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.salesloft.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.saltedge.discriminated_connection_settings"
@@ -1856,28 +1640,19 @@
                         "$ref": "#/components/schemas/connector.twenty.discriminated_connection_settings"
                       },
                       {
-                        "$ref": "#/components/schemas/connector.twitter.discriminated_connection_settings"
-                      },
-                      {
                         "$ref": "#/components/schemas/connector.venmo.discriminated_connection_settings"
                       },
                       {
                         "$ref": "#/components/schemas/connector.wise.discriminated_connection_settings"
                       },
                       {
-                        "$ref": "#/components/schemas/connector.xero.discriminated_connection_settings"
-                      },
-                      {
                         "$ref": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
-                      },
-                      {
-                        "$ref": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
                       }
                     ],
                     "discriminator": {
                       "propertyName": "connector_name",
                       "mapping": {
-                        "dummy-oauth2": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings",
+                        "acme-oauth2": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings",
                         "sharepointonline": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings",
                         "slack": "#/components/schemas/connector.slack.discriminated_connection_settings",
                         "github": "#/components/schemas/connector.github.discriminated_connection_settings",
@@ -1899,43 +1674,28 @@
                         "apollo": "#/components/schemas/connector.apollo.discriminated_connection_settings",
                         "brex": "#/components/schemas/connector.brex.discriminated_connection_settings",
                         "coda": "#/components/schemas/connector.coda.discriminated_connection_settings",
-                        "facebook": "#/components/schemas/connector.facebook.discriminated_connection_settings",
                         "finch": "#/components/schemas/connector.finch.discriminated_connection_settings",
                         "firebase": "#/components/schemas/connector.firebase.discriminated_connection_settings",
                         "foreceipt": "#/components/schemas/connector.foreceipt.discriminated_connection_settings",
-                        "gong": "#/components/schemas/connector.gong.discriminated_connection_settings",
                         "greenhouse": "#/components/schemas/connector.greenhouse.discriminated_connection_settings",
                         "heron": "#/components/schemas/connector.heron.discriminated_connection_settings",
-                        "instagram": "#/components/schemas/connector.instagram.discriminated_connection_settings",
-                        "intercom": "#/components/schemas/connector.intercom.discriminated_connection_settings",
-                        "jira": "#/components/schemas/connector.jira.discriminated_connection_settings",
-                        "kustomer": "#/components/schemas/connector.kustomer.discriminated_connection_settings",
-                        "lever": "#/components/schemas/connector.lever.discriminated_connection_settings",
                         "lunchmoney": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings",
                         "mercury": "#/components/schemas/connector.mercury.discriminated_connection_settings",
                         "merge": "#/components/schemas/connector.merge.discriminated_connection_settings",
-                        "microsoft": "#/components/schemas/connector.microsoft.discriminated_connection_settings",
                         "moota": "#/components/schemas/connector.moota.discriminated_connection_settings",
                         "onebrick": "#/components/schemas/connector.onebrick.discriminated_connection_settings",
-                        "outreach": "#/components/schemas/connector.outreach.discriminated_connection_settings",
-                        "pipedrive": "#/components/schemas/connector.pipedrive.discriminated_connection_settings",
                         "plaid": "#/components/schemas/connector.plaid.discriminated_connection_settings",
                         "postgres": "#/components/schemas/connector.postgres.discriminated_connection_settings",
                         "ramp": "#/components/schemas/connector.ramp.discriminated_connection_settings",
-                        "reddit": "#/components/schemas/connector.reddit.discriminated_connection_settings",
-                        "salesloft": "#/components/schemas/connector.salesloft.discriminated_connection_settings",
                         "saltedge": "#/components/schemas/connector.saltedge.discriminated_connection_settings",
                         "splitwise": "#/components/schemas/connector.splitwise.discriminated_connection_settings",
                         "stripe": "#/components/schemas/connector.stripe.discriminated_connection_settings",
                         "teller": "#/components/schemas/connector.teller.discriminated_connection_settings",
                         "toggl": "#/components/schemas/connector.toggl.discriminated_connection_settings",
                         "twenty": "#/components/schemas/connector.twenty.discriminated_connection_settings",
-                        "twitter": "#/components/schemas/connector.twitter.discriminated_connection_settings",
                         "venmo": "#/components/schemas/connector.venmo.discriminated_connection_settings",
                         "wise": "#/components/schemas/connector.wise.discriminated_connection_settings",
-                        "xero": "#/components/schemas/connector.xero.discriminated_connection_settings",
-                        "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings",
-                        "zohodesk": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
+                        "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
                       }
                     },
                     "description": "Connector specific data"
@@ -2631,6 +2391,145 @@
         ],
         "title": "AuthMode"
       },
+      "connector.acme-oauth2.discriminated_connection_settings": {
+        "type": "object",
+        "properties": {
+          "connector_name": {
+            "type": "string",
+            "const": "acme-oauth2"
+          },
+          "settings": {
+            "type": "object",
+            "properties": {
+              "oauth": {
+                "type": "object",
+                "properties": {
+                  "credentials": {
+                    "type": "object",
+                    "properties": {
+                      "access_token": {
+                        "type": "string"
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID used for the connection"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "refresh_token": {
+                        "type": "string"
+                      },
+                      "expires_in": {
+                        "type": "number"
+                      },
+                      "expires_at": {
+                        "type": "string"
+                      },
+                      "token_type": {
+                        "type": "string"
+                      },
+                      "raw": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "required": [
+                      "access_token",
+                      "scope",
+                      "raw"
+                    ],
+                    "description": "Output of the postConnect hook for oauth2 connectors"
+                  },
+                  "created_at": {
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "type": "string"
+                  },
+                  "last_fetched_at": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {}
+                  }
+                }
+              }
+            },
+            "required": [
+              "oauth"
+            ]
+          }
+        },
+        "required": [
+          "connector_name",
+          "settings"
+        ],
+        "title": "acme-oauth2"
+      },
+      "connector.acme-oauth2.discriminated_connector_config": {
+        "type": "object",
+        "properties": {
+          "connector_name": {
+            "type": "string",
+            "const": "acme-oauth2"
+          },
+          "config": {
+            "type": "object",
+            "properties": {
+              "oauth": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "client_secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "scopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "redirect_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
+              }
+            },
+            "required": [
+              "oauth"
+            ]
+          }
+        },
+        "required": [
+          "connector_name",
+          "config"
+        ],
+        "title": "acme-oauth2"
+      },
       "connector.aircall.discriminated_connection_settings": {
         "type": "object",
         "properties": {
@@ -2755,7 +2654,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -3231,7 +3131,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -3369,7 +3270,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -3382,341 +3284,6 @@
           "config"
         ],
         "title": "discord"
-      },
-      "connector.dummy-oauth2.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "dummy-oauth2"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "client_id": {
-                        "type": "string",
-                        "description": "Client ID used for the connection"
-                      },
-                      "scope": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_in": {
-                        "type": "number"
-                      },
-                      "expires_at": {
-                        "type": "string"
-                      },
-                      "token_type": {
-                        "type": "string"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "additionalProperties": {}
-                      }
-                    },
-                    "required": [
-                      "access_token",
-                      "scope",
-                      "raw"
-                    ],
-                    "description": "Output of the postConnect hook for oauth2 connectors"
-                  },
-                  "created_at": {
-                    "type": "string"
-                  },
-                  "updated_at": {
-                    "type": "string"
-                  },
-                  "last_fetched_at": {
-                    "type": "string"
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                }
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "dummy-oauth2"
-      },
-      "connector.dummy-oauth2.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "dummy-oauth2"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "client_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "client_secret": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "scopes": {
-                    "type": [
-                      "array",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "redirect_uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "description": "Base oauth configuration for the connector"
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "dummy-oauth2"
-      },
-      "connector.facebook.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "facebook"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "facebook"
-      },
-      "connector.facebook.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "facebook"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "facebook"
       },
       "connector.finch.discriminated_connection_settings": {
         "type": "object",
@@ -4152,7 +3719,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -4165,203 +3733,6 @@
           "config"
         ],
         "title": "github"
-      },
-      "connector.gong.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "gong"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "gong"
-      },
-      "connector.gong.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "gong"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "gong"
       },
       "connector.googlecalendar.discriminated_connection_settings": {
         "type": "object",
@@ -4487,7 +3858,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -4625,7 +3997,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -4763,7 +4136,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -4901,7 +4275,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -5039,7 +4414,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -5263,7 +4639,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -5276,999 +4653,6 @@
           "config"
         ],
         "title": "hubspot"
-      },
-      "connector.instagram.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "instagram"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "instagram"
-      },
-      "connector.instagram.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "instagram"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "instagram"
-      },
-      "connector.intercom.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "intercom"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "intercom"
-      },
-      "connector.intercom.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "intercom"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "intercom"
-      },
-      "connector.jira.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "jira"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "jira"
-      },
-      "connector.jira.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "jira"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "jira"
-      },
-      "connector.kustomer.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "kustomer"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "kustomer"
-      },
-      "connector.kustomer.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "kustomer"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "kustomer"
-      },
-      "connector.lever.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "lever"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "lever"
-      },
-      "connector.lever.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "lever"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              },
-              "envName": {
-                "type": "string",
-                "enum": [
-                  "sandbox",
-                  "production"
-                ]
-              }
-            },
-            "required": [
-              "oauth",
-              "envName"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "lever"
       },
       "connector.linear.discriminated_connection_settings": {
         "type": "object",
@@ -6394,7 +4778,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -6532,7 +4917,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -6706,249 +5092,6 @@
         ],
         "title": "merge"
       },
-      "connector.microsoft.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "microsoft"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              },
-              "client_id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "microsoft"
-      },
-      "connector.microsoft.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "microsoft"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string",
-                    "description": "global microsoft connector space separated scopes"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              },
-              "integrations": {
-                "type": "object",
-                "properties": {
-                  "sharepoint": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean"
-                      },
-                      "scopes": {
-                        "type": "string",
-                        "description": "sharepoint specific space separated scopes"
-                      }
-                    }
-                  },
-                  "outlook": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean"
-                      },
-                      "scopes": {
-                        "type": "string",
-                        "description": "outlook specific space separated scopes"
-                      }
-                    }
-                  },
-                  "teams": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean"
-                      },
-                      "scopes": {
-                        "type": "string",
-                        "description": "teams specific space separated scopes"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "required": [
-              "oauth",
-              "integrations"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "microsoft"
-      },
       "connector.moota.discriminated_connection_settings": {
         "type": "object",
         "properties": {
@@ -7116,7 +5259,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -7207,400 +5351,6 @@
           "config"
         ],
         "title": "onebrick"
-      },
-      "connector.outreach.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "outreach"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "outreach"
-      },
-      "connector.outreach.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "outreach"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "outreach"
-      },
-      "connector.pipedrive.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "pipedrive"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "pipedrive"
-      },
-      "connector.pipedrive.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "pipedrive"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "pipedrive"
       },
       "connector.plaid.discriminated_connection_settings": {
         "type": "object",
@@ -7716,7 +5466,7 @@
                 "default": [
                   "transactions"
                 ],
-                "ui:field": "MultiSelectField"
+                "ui:widget": "MultiSelectWidget"
               },
               "countryCodes": {
                 "type": "array",
@@ -7745,7 +5495,7 @@
                   "US",
                   "CA"
                 ],
-                "ui:field": "MultiSelectField"
+                "ui:widget": "MultiSelectWidget"
               },
               "language": {
                 "type": "string",
@@ -7959,7 +5709,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               },
               "envName": {
                 "type": "string",
@@ -8049,203 +5800,6 @@
           "config"
         ],
         "title": "ramp"
-      },
-      "connector.reddit.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "reddit"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "reddit"
-      },
-      "connector.reddit.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "reddit"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "reddit"
       },
       "connector.salesforce.discriminated_connection_settings": {
         "type": "object",
@@ -8377,7 +5931,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -8390,203 +5945,6 @@
           "config"
         ],
         "title": "salesforce"
-      },
-      "connector.salesloft.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "salesloft"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "salesloft"
-      },
-      "connector.salesloft.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "salesloft"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "salesloft"
       },
       "connector.saltedge.discriminated_connection_settings": {
         "type": "object",
@@ -8761,7 +6119,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -8899,7 +6258,8 @@
                     ]
                   }
                 },
-                "description": "Base oauth configuration for the connector"
+                "description": "Base oauth configuration for the connector",
+                "ui:field": "OAuthField"
               }
             },
             "required": [
@@ -9331,203 +6691,6 @@
         ],
         "title": "twenty"
       },
-      "connector.twitter.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "twitter"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "twitter"
-      },
-      "connector.twitter.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "twitter"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "twitter"
-      },
       "connector.venmo.discriminated_connection_settings": {
         "type": "object",
         "properties": {
@@ -9650,203 +6813,6 @@
           "config"
         ],
         "title": "wise"
-      },
-      "connector.xero.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "xero"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "xero"
-      },
-      "connector.xero.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "xero"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "xero"
       },
       "connector.yodlee.discriminated_connection_settings": {
         "type": "object",
@@ -10031,203 +6997,6 @@
         ],
         "title": "yodlee"
       },
-      "connector.zohodesk.discriminated_connection_settings": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "zohodesk"
-          },
-          "settings": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "credentials": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "$ref": "#/components/schemas/AuthMode"
-                      },
-                      "api_key": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "access_token": {
-                        "type": "string"
-                      },
-                      "refresh_token": {
-                        "type": "string"
-                      },
-                      "expires_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "raw": {
-                        "type": "object",
-                        "properties": {
-                          "access_token": {
-                            "type": "string"
-                          },
-                          "expires_in": {
-                            "type": "number"
-                          },
-                          "expires_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "refresh_token": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "refresh_token_expires_in": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "token_type": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "scope": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "access_token"
-                        ],
-                        "additionalProperties": true
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "raw"
-                    ]
-                  },
-                  "connection_config": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "properties": {
-                      "portalId": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "instance_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    },
-                    "additionalProperties": {}
-                  },
-                  "metadata": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "additionalProperties": {}
-                  }
-                },
-                "required": [
-                  "credentials",
-                  "metadata"
-                ]
-              },
-              "error": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "code": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refresh_token_external_error"
-                        ]
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "message": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "code"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "settings"
-        ],
-        "title": "zohodesk"
-      },
-      "connector.zohodesk.discriminated_connector_config": {
-        "type": "object",
-        "properties": {
-          "connector_name": {
-            "type": "string",
-            "const": "zohodesk"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "oauth": {
-                "type": "object",
-                "properties": {
-                  "client_id": {
-                    "type": "string"
-                  },
-                  "client_secret": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "client_id",
-                  "client_secret"
-                ]
-              }
-            },
-            "required": [
-              "oauth"
-            ]
-          }
-        },
-        "required": [
-          "connector_name",
-          "config"
-        ],
-        "title": "zohodesk"
-      },
       "core.connection_select": {
         "allOf": [
           {
@@ -10292,7 +7061,7 @@
           {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings"
+                "$ref": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings"
@@ -10358,9 +7127,6 @@
                 "$ref": "#/components/schemas/connector.coda.discriminated_connection_settings"
               },
               {
-                "$ref": "#/components/schemas/connector.facebook.discriminated_connection_settings"
-              },
-              {
                 "$ref": "#/components/schemas/connector.finch.discriminated_connection_settings"
               },
               {
@@ -10370,28 +7136,10 @@
                 "$ref": "#/components/schemas/connector.foreceipt.discriminated_connection_settings"
               },
               {
-                "$ref": "#/components/schemas/connector.gong.discriminated_connection_settings"
-              },
-              {
                 "$ref": "#/components/schemas/connector.greenhouse.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.heron.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.instagram.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.intercom.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.jira.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.kustomer.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.lever.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings"
@@ -10403,19 +7151,10 @@
                 "$ref": "#/components/schemas/connector.merge.discriminated_connection_settings"
               },
               {
-                "$ref": "#/components/schemas/connector.microsoft.discriminated_connection_settings"
-              },
-              {
                 "$ref": "#/components/schemas/connector.moota.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.onebrick.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.outreach.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.pipedrive.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.plaid.discriminated_connection_settings"
@@ -10425,12 +7164,6 @@
               },
               {
                 "$ref": "#/components/schemas/connector.ramp.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.reddit.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.salesloft.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.saltedge.discriminated_connection_settings"
@@ -10451,28 +7184,19 @@
                 "$ref": "#/components/schemas/connector.twenty.discriminated_connection_settings"
               },
               {
-                "$ref": "#/components/schemas/connector.twitter.discriminated_connection_settings"
-              },
-              {
                 "$ref": "#/components/schemas/connector.venmo.discriminated_connection_settings"
               },
               {
                 "$ref": "#/components/schemas/connector.wise.discriminated_connection_settings"
               },
               {
-                "$ref": "#/components/schemas/connector.xero.discriminated_connection_settings"
-              },
-              {
                 "$ref": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
-              },
-              {
-                "$ref": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
               }
             ],
             "discriminator": {
               "propertyName": "connector_name",
               "mapping": {
-                "dummy-oauth2": "#/components/schemas/connector.dummy-oauth2.discriminated_connection_settings",
+                "acme-oauth2": "#/components/schemas/connector.acme-oauth2.discriminated_connection_settings",
                 "sharepointonline": "#/components/schemas/connector.sharepointonline.discriminated_connection_settings",
                 "slack": "#/components/schemas/connector.slack.discriminated_connection_settings",
                 "github": "#/components/schemas/connector.github.discriminated_connection_settings",
@@ -10494,43 +7218,28 @@
                 "apollo": "#/components/schemas/connector.apollo.discriminated_connection_settings",
                 "brex": "#/components/schemas/connector.brex.discriminated_connection_settings",
                 "coda": "#/components/schemas/connector.coda.discriminated_connection_settings",
-                "facebook": "#/components/schemas/connector.facebook.discriminated_connection_settings",
                 "finch": "#/components/schemas/connector.finch.discriminated_connection_settings",
                 "firebase": "#/components/schemas/connector.firebase.discriminated_connection_settings",
                 "foreceipt": "#/components/schemas/connector.foreceipt.discriminated_connection_settings",
-                "gong": "#/components/schemas/connector.gong.discriminated_connection_settings",
                 "greenhouse": "#/components/schemas/connector.greenhouse.discriminated_connection_settings",
                 "heron": "#/components/schemas/connector.heron.discriminated_connection_settings",
-                "instagram": "#/components/schemas/connector.instagram.discriminated_connection_settings",
-                "intercom": "#/components/schemas/connector.intercom.discriminated_connection_settings",
-                "jira": "#/components/schemas/connector.jira.discriminated_connection_settings",
-                "kustomer": "#/components/schemas/connector.kustomer.discriminated_connection_settings",
-                "lever": "#/components/schemas/connector.lever.discriminated_connection_settings",
                 "lunchmoney": "#/components/schemas/connector.lunchmoney.discriminated_connection_settings",
                 "mercury": "#/components/schemas/connector.mercury.discriminated_connection_settings",
                 "merge": "#/components/schemas/connector.merge.discriminated_connection_settings",
-                "microsoft": "#/components/schemas/connector.microsoft.discriminated_connection_settings",
                 "moota": "#/components/schemas/connector.moota.discriminated_connection_settings",
                 "onebrick": "#/components/schemas/connector.onebrick.discriminated_connection_settings",
-                "outreach": "#/components/schemas/connector.outreach.discriminated_connection_settings",
-                "pipedrive": "#/components/schemas/connector.pipedrive.discriminated_connection_settings",
                 "plaid": "#/components/schemas/connector.plaid.discriminated_connection_settings",
                 "postgres": "#/components/schemas/connector.postgres.discriminated_connection_settings",
                 "ramp": "#/components/schemas/connector.ramp.discriminated_connection_settings",
-                "reddit": "#/components/schemas/connector.reddit.discriminated_connection_settings",
-                "salesloft": "#/components/schemas/connector.salesloft.discriminated_connection_settings",
                 "saltedge": "#/components/schemas/connector.saltedge.discriminated_connection_settings",
                 "splitwise": "#/components/schemas/connector.splitwise.discriminated_connection_settings",
                 "stripe": "#/components/schemas/connector.stripe.discriminated_connection_settings",
                 "teller": "#/components/schemas/connector.teller.discriminated_connection_settings",
                 "toggl": "#/components/schemas/connector.toggl.discriminated_connection_settings",
                 "twenty": "#/components/schemas/connector.twenty.discriminated_connection_settings",
-                "twitter": "#/components/schemas/connector.twitter.discriminated_connection_settings",
                 "venmo": "#/components/schemas/connector.venmo.discriminated_connection_settings",
                 "wise": "#/components/schemas/connector.wise.discriminated_connection_settings",
-                "xero": "#/components/schemas/connector.xero.discriminated_connection_settings",
-                "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings",
-                "zohodesk": "#/components/schemas/connector.zohodesk.discriminated_connection_settings"
+                "yodlee": "#/components/schemas/connector.yodlee.discriminated_connection_settings"
               }
             },
             "description": "Connector specific data"
@@ -10631,6 +7340,7 @@
       "core.connector.name": {
         "type": "string",
         "enum": [
+          "acme-oauth2",
           "aircall",
           "airtable",
           "apollo",
@@ -10638,13 +7348,10 @@
           "coda",
           "confluence",
           "discord",
-          "dummy-oauth2",
-          "facebook",
           "finch",
           "firebase",
           "foreceipt",
           "github",
-          "gong",
           "googlecalendar",
           "googledocs",
           "googledrive",
@@ -10653,29 +7360,19 @@
           "greenhouse",
           "heron",
           "hubspot",
-          "instagram",
-          "intercom",
-          "jira",
-          "kustomer",
-          "lever",
           "linear",
           "linkedin",
           "lunchmoney",
           "mercury",
           "merge",
-          "microsoft",
           "moota",
           "notion",
           "onebrick",
-          "outreach",
-          "pipedrive",
           "plaid",
           "postgres",
           "quickbooks",
           "ramp",
-          "reddit",
           "salesforce",
-          "salesloft",
           "saltedge",
           "sharepointonline",
           "slack",
@@ -10684,12 +7381,9 @@
           "teller",
           "toggl",
           "twenty",
-          "twitter",
           "venmo",
           "wise",
-          "xero",
-          "yodlee",
-          "zohodesk"
+          "yodlee"
         ],
         "title": "connector"
       },

--- a/packages/api-v1/__generated__/openapi.types.ts
+++ b/packages/api-v1/__generated__/openapi.types.ts
@@ -201,6 +201,55 @@ export interface components {
          * @enum {string}
          */
         AuthMode: "OAUTH2" | "OAUTH1" | "BASIC" | "API_KEY";
+        /** acme-oauth2 */
+        "connector.acme-oauth2.discriminated_connection_settings": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            connector_name: "acme-oauth2";
+            settings: {
+                oauth: {
+                    /** @description Output of the postConnect hook for oauth2 connectors */
+                    credentials?: {
+                        access_token: string;
+                        /** @description Client ID used for the connection */
+                        client_id?: string;
+                        scope: string;
+                        refresh_token?: string;
+                        expires_in?: number;
+                        expires_at?: string;
+                        token_type?: string;
+                        raw: {
+                            [key: string]: unknown;
+                        };
+                    };
+                    created_at?: string;
+                    updated_at?: string;
+                    last_fetched_at?: string;
+                    metadata?: {
+                        [key: string]: unknown;
+                    } | null;
+                };
+            };
+        };
+        /** acme-oauth2 */
+        "connector.acme-oauth2.discriminated_connector_config": {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            connector_name: "acme-oauth2";
+            config: {
+                /** @description Base oauth configuration for the connector */
+                oauth: {
+                    client_id?: string | null;
+                    client_secret?: string | null;
+                    scopes?: string[] | null;
+                    redirect_uri?: string | null;
+                } | null;
+            };
+        };
         /** aircall */
         "connector.aircall.discriminated_connection_settings": {
             /**
@@ -471,115 +520,6 @@ export interface components {
                 } | null;
             };
         };
-        /** dummy-oauth2 */
-        "connector.dummy-oauth2.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "dummy-oauth2";
-            settings: {
-                oauth: {
-                    /** @description Output of the postConnect hook for oauth2 connectors */
-                    credentials?: {
-                        access_token: string;
-                        /** @description Client ID used for the connection */
-                        client_id?: string;
-                        scope: string;
-                        refresh_token?: string;
-                        expires_in?: number;
-                        expires_at?: string;
-                        token_type?: string;
-                        raw: {
-                            [key: string]: unknown;
-                        };
-                    };
-                    created_at?: string;
-                    updated_at?: string;
-                    last_fetched_at?: string;
-                    metadata?: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-            };
-        };
-        /** dummy-oauth2 */
-        "connector.dummy-oauth2.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "dummy-oauth2";
-            config: {
-                /** @description Base oauth configuration for the connector */
-                oauth: {
-                    client_id?: string | null;
-                    client_secret?: string | null;
-                    scopes?: string[] | null;
-                    redirect_uri?: string | null;
-                } | null;
-            };
-        };
-        /** facebook */
-        "connector.facebook.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "facebook";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** facebook */
-        "connector.facebook.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "facebook";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
         /** finch */
         "connector.finch.discriminated_connection_settings": {
             /**
@@ -738,66 +678,6 @@ export interface components {
                     scopes?: string[] | null;
                     redirect_uri?: string | null;
                 } | null;
-            };
-        };
-        /** gong */
-        "connector.gong.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "gong";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** gong */
-        "connector.gong.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "gong";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
             };
         };
         /** googlecalendar */
@@ -1134,308 +1014,6 @@ export interface components {
                 } | null;
             };
         };
-        /** instagram */
-        "connector.instagram.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "instagram";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** instagram */
-        "connector.instagram.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "instagram";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
-        /** intercom */
-        "connector.intercom.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "intercom";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** intercom */
-        "connector.intercom.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "intercom";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
-        /** jira */
-        "connector.jira.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "jira";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** jira */
-        "connector.jira.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "jira";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
-        /** kustomer */
-        "connector.kustomer.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "kustomer";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** kustomer */
-        "connector.kustomer.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "kustomer";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
-        /** lever */
-        "connector.lever.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "lever";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** lever */
-        "connector.lever.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "lever";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-                /** @enum {string} */
-                envName: "sandbox" | "production";
-            };
-        };
         /** linear */
         "connector.linear.discriminated_connection_settings": {
             /**
@@ -1603,85 +1181,6 @@ export interface components {
                 apiKey: string;
             };
         };
-        /** microsoft */
-        "connector.microsoft.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "microsoft";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-                client_id?: string;
-            };
-        };
-        /** microsoft */
-        "connector.microsoft.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "microsoft";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    /** @description global microsoft connector space separated scopes */
-                    scopes?: string;
-                };
-                integrations: {
-                    sharepoint?: {
-                        enabled?: boolean;
-                        /** @description sharepoint specific space separated scopes */
-                        scopes?: string;
-                    };
-                    outlook?: {
-                        enabled?: boolean;
-                        /** @description outlook specific space separated scopes */
-                        scopes?: string;
-                    };
-                    teams?: {
-                        enabled?: boolean;
-                        /** @description teams specific space separated scopes */
-                        scopes?: string;
-                    };
-                };
-            };
-        };
         /** moota */
         "connector.moota.discriminated_connection_settings": {
             /**
@@ -1777,126 +1276,6 @@ export interface components {
                 publicToken: string;
                 accessToken?: string | null;
                 redirectUrl?: string | null;
-            };
-        };
-        /** outreach */
-        "connector.outreach.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "outreach";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** outreach */
-        "connector.outreach.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "outreach";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
-        /** pipedrive */
-        "connector.pipedrive.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "pipedrive";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** pipedrive */
-        "connector.pipedrive.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "pipedrive";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
             };
         };
         /** plaid */
@@ -2058,66 +1437,6 @@ export interface components {
                 };
             };
         };
-        /** reddit */
-        "connector.reddit.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "reddit";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** reddit */
-        "connector.reddit.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "reddit";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
         /** salesforce */
         "connector.salesforce.discriminated_connection_settings": {
             /**
@@ -2167,66 +1486,6 @@ export interface components {
                     scopes?: string[] | null;
                     redirect_uri?: string | null;
                 } | null;
-            };
-        };
-        /** salesloft */
-        "connector.salesloft.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "salesloft";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** salesloft */
-        "connector.salesloft.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "salesloft";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
             };
         };
         /** saltedge */
@@ -2496,66 +1755,6 @@ export interface components {
             connector_name: "twenty";
             config: Record<string, never>;
         };
-        /** twitter */
-        "connector.twitter.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "twitter";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** twitter */
-        "connector.twitter.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "twitter";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
         /** venmo */
         "connector.venmo.discriminated_connection_settings": {
             /**
@@ -2605,66 +1804,6 @@ export interface components {
              */
             connector_name: "wise";
             config: Record<string, never>;
-        };
-        /** xero */
-        "connector.xero.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "xero";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** xero */
-        "connector.xero.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "xero";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
         };
         /** yodlee */
         "connector.yodlee.discriminated_connection_settings": {
@@ -2716,66 +1855,6 @@ export interface components {
                 } | null;
             };
         };
-        /** zohodesk */
-        "connector.zohodesk.discriminated_connection_settings": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "zohodesk";
-            settings: {
-                oauth: {
-                    credentials: {
-                        type: components["schemas"]["AuthMode"];
-                        api_key?: string | null;
-                        access_token?: string;
-                        refresh_token?: string;
-                        /** Format: date-time */
-                        expires_at?: string;
-                        raw: {
-                            access_token: string;
-                            expires_in?: number;
-                            /** Format: date-time */
-                            expires_at?: string;
-                            refresh_token?: string | null;
-                            refresh_token_expires_in?: number | null;
-                            token_type?: string | null;
-                            scope?: string;
-                        } & {
-                            [key: string]: unknown;
-                        };
-                    };
-                    connection_config?: ({
-                        portalId?: number | null;
-                        instance_url?: string | null;
-                    } & {
-                        [key: string]: unknown;
-                    }) | null;
-                    metadata: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-                error?: {
-                    code: "refresh_token_external_error" | string;
-                    message?: string | null;
-                } | null;
-            };
-        };
-        /** zohodesk */
-        "connector.zohodesk.discriminated_connector_config": {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            connector_name: "zohodesk";
-            config: {
-                oauth: {
-                    client_id: string;
-                    client_secret: string;
-                    scopes?: string;
-                };
-            };
-        };
         /** connection_select */
         "core.connection_select": {
             connector_name: "core.connection_select";
@@ -2796,7 +1875,7 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             } | null;
-        } & Omit<components["schemas"]["connector.dummy-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.facebook.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.gong.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.instagram.discriminated_connection_settings"] | components["schemas"]["connector.intercom.discriminated_connection_settings"] | components["schemas"]["connector.jira.discriminated_connection_settings"] | components["schemas"]["connector.kustomer.discriminated_connection_settings"] | components["schemas"]["connector.lever.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.microsoft.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.outreach.discriminated_connection_settings"] | components["schemas"]["connector.pipedrive.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.reddit.discriminated_connection_settings"] | components["schemas"]["connector.salesloft.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.twitter.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.xero.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"] | components["schemas"]["connector.zohodesk.discriminated_connection_settings"], "connector_name">);
+        } & Omit<components["schemas"]["connector.acme-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"], "connector_name">);
         /** Connector */
         "core.connector": {
             name: string;
@@ -2827,7 +1906,7 @@ export interface components {
          * connector
          * @enum {string}
          */
-        "core.connector.name": "aircall" | "airtable" | "apollo" | "brex" | "coda" | "confluence" | "discord" | "dummy-oauth2" | "facebook" | "finch" | "firebase" | "foreceipt" | "github" | "gong" | "googlecalendar" | "googledocs" | "googledrive" | "googlemail" | "googlesheet" | "greenhouse" | "heron" | "hubspot" | "instagram" | "intercom" | "jira" | "kustomer" | "lever" | "linear" | "linkedin" | "lunchmoney" | "mercury" | "merge" | "microsoft" | "moota" | "notion" | "onebrick" | "outreach" | "pipedrive" | "plaid" | "postgres" | "quickbooks" | "ramp" | "reddit" | "salesforce" | "salesloft" | "saltedge" | "sharepointonline" | "slack" | "splitwise" | "stripe" | "teller" | "toggl" | "twenty" | "twitter" | "venmo" | "wise" | "xero" | "yodlee" | "zohodesk";
+        "core.connector.name": "acme-oauth2" | "aircall" | "airtable" | "apollo" | "brex" | "coda" | "confluence" | "discord" | "finch" | "firebase" | "foreceipt" | "github" | "googlecalendar" | "googledocs" | "googledrive" | "googlemail" | "googlesheet" | "greenhouse" | "heron" | "hubspot" | "linear" | "linkedin" | "lunchmoney" | "mercury" | "merge" | "moota" | "notion" | "onebrick" | "plaid" | "postgres" | "quickbooks" | "ramp" | "salesforce" | "saltedge" | "sharepointonline" | "slack" | "splitwise" | "stripe" | "teller" | "toggl" | "twenty" | "venmo" | "wise" | "yodlee";
         /** integration_select */
         "core.integration_select": {
             id: string;
@@ -3117,7 +2196,7 @@ export interface operations {
                             metadata?: {
                                 [key: string]: unknown;
                             } | null;
-                        } & Omit<components["schemas"]["connector.dummy-oauth2.discriminated_connector_config"] | components["schemas"]["connector.sharepointonline.discriminated_connector_config"] | components["schemas"]["connector.slack.discriminated_connector_config"] | components["schemas"]["connector.github.discriminated_connector_config"] | components["schemas"]["connector.quickbooks.discriminated_connector_config"] | components["schemas"]["connector.googlemail.discriminated_connector_config"] | components["schemas"]["connector.notion.discriminated_connector_config"] | components["schemas"]["connector.linkedin.discriminated_connector_config"] | components["schemas"]["connector.googledocs.discriminated_connector_config"] | components["schemas"]["connector.aircall.discriminated_connector_config"] | components["schemas"]["connector.googlecalendar.discriminated_connector_config"] | components["schemas"]["connector.googlesheet.discriminated_connector_config"] | components["schemas"]["connector.discord.discriminated_connector_config"] | components["schemas"]["connector.hubspot.discriminated_connector_config"] | components["schemas"]["connector.salesforce.discriminated_connector_config"] | components["schemas"]["connector.linear.discriminated_connector_config"] | components["schemas"]["connector.confluence.discriminated_connector_config"] | components["schemas"]["connector.googledrive.discriminated_connector_config"] | components["schemas"]["connector.airtable.discriminated_connector_config"] | components["schemas"]["connector.apollo.discriminated_connector_config"] | components["schemas"]["connector.brex.discriminated_connector_config"] | components["schemas"]["connector.coda.discriminated_connector_config"] | components["schemas"]["connector.facebook.discriminated_connector_config"] | components["schemas"]["connector.finch.discriminated_connector_config"] | components["schemas"]["connector.firebase.discriminated_connector_config"] | components["schemas"]["connector.foreceipt.discriminated_connector_config"] | components["schemas"]["connector.gong.discriminated_connector_config"] | components["schemas"]["connector.greenhouse.discriminated_connector_config"] | components["schemas"]["connector.heron.discriminated_connector_config"] | components["schemas"]["connector.instagram.discriminated_connector_config"] | components["schemas"]["connector.intercom.discriminated_connector_config"] | components["schemas"]["connector.jira.discriminated_connector_config"] | components["schemas"]["connector.kustomer.discriminated_connector_config"] | components["schemas"]["connector.lever.discriminated_connector_config"] | components["schemas"]["connector.lunchmoney.discriminated_connector_config"] | components["schemas"]["connector.mercury.discriminated_connector_config"] | components["schemas"]["connector.merge.discriminated_connector_config"] | components["schemas"]["connector.microsoft.discriminated_connector_config"] | components["schemas"]["connector.moota.discriminated_connector_config"] | components["schemas"]["connector.onebrick.discriminated_connector_config"] | components["schemas"]["connector.outreach.discriminated_connector_config"] | components["schemas"]["connector.pipedrive.discriminated_connector_config"] | components["schemas"]["connector.plaid.discriminated_connector_config"] | components["schemas"]["connector.postgres.discriminated_connector_config"] | components["schemas"]["connector.ramp.discriminated_connector_config"] | components["schemas"]["connector.reddit.discriminated_connector_config"] | components["schemas"]["connector.salesloft.discriminated_connector_config"] | components["schemas"]["connector.saltedge.discriminated_connector_config"] | components["schemas"]["connector.splitwise.discriminated_connector_config"] | components["schemas"]["connector.stripe.discriminated_connector_config"] | components["schemas"]["connector.teller.discriminated_connector_config"] | components["schemas"]["connector.toggl.discriminated_connector_config"] | components["schemas"]["connector.twenty.discriminated_connector_config"] | components["schemas"]["connector.twitter.discriminated_connector_config"] | components["schemas"]["connector.venmo.discriminated_connector_config"] | components["schemas"]["connector.wise.discriminated_connector_config"] | components["schemas"]["connector.xero.discriminated_connector_config"] | components["schemas"]["connector.yodlee.discriminated_connector_config"] | components["schemas"]["connector.zohodesk.discriminated_connector_config"], "connector_name"> & {
+                        } & Omit<components["schemas"]["connector.acme-oauth2.discriminated_connector_config"] | components["schemas"]["connector.sharepointonline.discriminated_connector_config"] | components["schemas"]["connector.slack.discriminated_connector_config"] | components["schemas"]["connector.github.discriminated_connector_config"] | components["schemas"]["connector.quickbooks.discriminated_connector_config"] | components["schemas"]["connector.googlemail.discriminated_connector_config"] | components["schemas"]["connector.notion.discriminated_connector_config"] | components["schemas"]["connector.linkedin.discriminated_connector_config"] | components["schemas"]["connector.googledocs.discriminated_connector_config"] | components["schemas"]["connector.aircall.discriminated_connector_config"] | components["schemas"]["connector.googlecalendar.discriminated_connector_config"] | components["schemas"]["connector.googlesheet.discriminated_connector_config"] | components["schemas"]["connector.discord.discriminated_connector_config"] | components["schemas"]["connector.hubspot.discriminated_connector_config"] | components["schemas"]["connector.salesforce.discriminated_connector_config"] | components["schemas"]["connector.linear.discriminated_connector_config"] | components["schemas"]["connector.confluence.discriminated_connector_config"] | components["schemas"]["connector.googledrive.discriminated_connector_config"] | components["schemas"]["connector.airtable.discriminated_connector_config"] | components["schemas"]["connector.apollo.discriminated_connector_config"] | components["schemas"]["connector.brex.discriminated_connector_config"] | components["schemas"]["connector.coda.discriminated_connector_config"] | components["schemas"]["connector.finch.discriminated_connector_config"] | components["schemas"]["connector.firebase.discriminated_connector_config"] | components["schemas"]["connector.foreceipt.discriminated_connector_config"] | components["schemas"]["connector.greenhouse.discriminated_connector_config"] | components["schemas"]["connector.heron.discriminated_connector_config"] | components["schemas"]["connector.lunchmoney.discriminated_connector_config"] | components["schemas"]["connector.mercury.discriminated_connector_config"] | components["schemas"]["connector.merge.discriminated_connector_config"] | components["schemas"]["connector.moota.discriminated_connector_config"] | components["schemas"]["connector.onebrick.discriminated_connector_config"] | components["schemas"]["connector.plaid.discriminated_connector_config"] | components["schemas"]["connector.postgres.discriminated_connector_config"] | components["schemas"]["connector.ramp.discriminated_connector_config"] | components["schemas"]["connector.saltedge.discriminated_connector_config"] | components["schemas"]["connector.splitwise.discriminated_connector_config"] | components["schemas"]["connector.stripe.discriminated_connector_config"] | components["schemas"]["connector.teller.discriminated_connector_config"] | components["schemas"]["connector.toggl.discriminated_connector_config"] | components["schemas"]["connector.twenty.discriminated_connector_config"] | components["schemas"]["connector.venmo.discriminated_connector_config"] | components["schemas"]["connector.wise.discriminated_connector_config"] | components["schemas"]["connector.yodlee.discriminated_connector_config"], "connector_name"> & {
                             connector?: components["schemas"]["core.connector"];
                             integrations?: {
                                 [key: string]: components["schemas"]["core.integration_select"];
@@ -3227,7 +2306,7 @@ export interface operations {
                         metadata?: {
                             [key: string]: unknown;
                         } | null;
-                    } & Omit<components["schemas"]["connector.dummy-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.facebook.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.gong.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.instagram.discriminated_connection_settings"] | components["schemas"]["connector.intercom.discriminated_connection_settings"] | components["schemas"]["connector.jira.discriminated_connection_settings"] | components["schemas"]["connector.kustomer.discriminated_connection_settings"] | components["schemas"]["connector.lever.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.microsoft.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.outreach.discriminated_connection_settings"] | components["schemas"]["connector.pipedrive.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.reddit.discriminated_connection_settings"] | components["schemas"]["connector.salesloft.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.twitter.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.xero.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"] | components["schemas"]["connector.zohodesk.discriminated_connection_settings"], "connector_name"> & {
+                    } & Omit<components["schemas"]["connector.acme-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"], "connector_name"> & {
                         connector?: components["schemas"]["core.connector"];
                     };
                 };
@@ -3394,7 +2473,7 @@ export interface operations {
                             metadata?: {
                                 [key: string]: unknown;
                             } | null;
-                        } & Omit<components["schemas"]["connector.dummy-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.facebook.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.gong.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.instagram.discriminated_connection_settings"] | components["schemas"]["connector.intercom.discriminated_connection_settings"] | components["schemas"]["connector.jira.discriminated_connection_settings"] | components["schemas"]["connector.kustomer.discriminated_connection_settings"] | components["schemas"]["connector.lever.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.microsoft.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.outreach.discriminated_connection_settings"] | components["schemas"]["connector.pipedrive.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.reddit.discriminated_connection_settings"] | components["schemas"]["connector.salesloft.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.twitter.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.xero.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"] | components["schemas"]["connector.zohodesk.discriminated_connection_settings"], "connector_name"> & {
+                        } & Omit<components["schemas"]["connector.acme-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"], "connector_name"> & {
                             connector?: components["schemas"]["core.connector"];
                         })[];
                         /** @description Total number of items in the database for the organization */
@@ -3477,7 +2556,7 @@ export interface operations {
                     /** @description The id of the customer in your application. Ensure it is unique for that customer. */
                     customer_id: string;
                     /** @description Connector specific data */
-                    data: components["schemas"]["connector.dummy-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.facebook.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.gong.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.instagram.discriminated_connection_settings"] | components["schemas"]["connector.intercom.discriminated_connection_settings"] | components["schemas"]["connector.jira.discriminated_connection_settings"] | components["schemas"]["connector.kustomer.discriminated_connection_settings"] | components["schemas"]["connector.lever.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.microsoft.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.outreach.discriminated_connection_settings"] | components["schemas"]["connector.pipedrive.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.reddit.discriminated_connection_settings"] | components["schemas"]["connector.salesloft.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.twitter.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.xero.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"] | components["schemas"]["connector.zohodesk.discriminated_connection_settings"];
+                    data: components["schemas"]["connector.acme-oauth2.discriminated_connection_settings"] | components["schemas"]["connector.sharepointonline.discriminated_connection_settings"] | components["schemas"]["connector.slack.discriminated_connection_settings"] | components["schemas"]["connector.github.discriminated_connection_settings"] | components["schemas"]["connector.quickbooks.discriminated_connection_settings"] | components["schemas"]["connector.googlemail.discriminated_connection_settings"] | components["schemas"]["connector.notion.discriminated_connection_settings"] | components["schemas"]["connector.linkedin.discriminated_connection_settings"] | components["schemas"]["connector.googledocs.discriminated_connection_settings"] | components["schemas"]["connector.aircall.discriminated_connection_settings"] | components["schemas"]["connector.googlecalendar.discriminated_connection_settings"] | components["schemas"]["connector.googlesheet.discriminated_connection_settings"] | components["schemas"]["connector.discord.discriminated_connection_settings"] | components["schemas"]["connector.hubspot.discriminated_connection_settings"] | components["schemas"]["connector.salesforce.discriminated_connection_settings"] | components["schemas"]["connector.linear.discriminated_connection_settings"] | components["schemas"]["connector.confluence.discriminated_connection_settings"] | components["schemas"]["connector.googledrive.discriminated_connection_settings"] | components["schemas"]["connector.airtable.discriminated_connection_settings"] | components["schemas"]["connector.apollo.discriminated_connection_settings"] | components["schemas"]["connector.brex.discriminated_connection_settings"] | components["schemas"]["connector.coda.discriminated_connection_settings"] | components["schemas"]["connector.finch.discriminated_connection_settings"] | components["schemas"]["connector.firebase.discriminated_connection_settings"] | components["schemas"]["connector.foreceipt.discriminated_connection_settings"] | components["schemas"]["connector.greenhouse.discriminated_connection_settings"] | components["schemas"]["connector.heron.discriminated_connection_settings"] | components["schemas"]["connector.lunchmoney.discriminated_connection_settings"] | components["schemas"]["connector.mercury.discriminated_connection_settings"] | components["schemas"]["connector.merge.discriminated_connection_settings"] | components["schemas"]["connector.moota.discriminated_connection_settings"] | components["schemas"]["connector.onebrick.discriminated_connection_settings"] | components["schemas"]["connector.plaid.discriminated_connection_settings"] | components["schemas"]["connector.postgres.discriminated_connection_settings"] | components["schemas"]["connector.ramp.discriminated_connection_settings"] | components["schemas"]["connector.saltedge.discriminated_connection_settings"] | components["schemas"]["connector.splitwise.discriminated_connection_settings"] | components["schemas"]["connector.stripe.discriminated_connection_settings"] | components["schemas"]["connector.teller.discriminated_connection_settings"] | components["schemas"]["connector.toggl.discriminated_connection_settings"] | components["schemas"]["connector.twenty.discriminated_connection_settings"] | components["schemas"]["connector.venmo.discriminated_connection_settings"] | components["schemas"]["connector.wise.discriminated_connection_settings"] | components["schemas"]["connector.yodlee.discriminated_connection_settings"];
                 };
             };
         };

--- a/packages/api-v1/app.ts
+++ b/packages/api-v1/app.ts
@@ -45,7 +45,7 @@ export function createApp(opts: CreateAppOptions) {
       createFetchHandlerOpenAPI({...opts, endpoint: '/v1'})(request),
     )
     // For testing purposes only
-    .group('/dummy-oauth2', (group) =>
+    .group('/acme-oauth2', (group) =>
       group.use(
         createOAuth2Server({
           // TODO: have a better way to unify this

--- a/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
+++ b/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
@@ -4,6 +4,194 @@ exports[`db: pglite list connectors with schemas 1`] = `
 [
   {
     "authType": "OAUTH2",
+    "display_name": "Acme Oauth2",
+    "logo_url": "https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-acme-oauth2.svg",
+    "name": "acme-oauth2",
+    "openint_scopes": [
+      "read:profile",
+    ],
+    "platforms": undefined,
+    "schemas": {
+      "connect_input": {
+        "properties": {
+          "authorization_url": {
+            "description": "URL to take user to for approval",
+            "type": "string",
+          },
+          "code_verifier": {
+            "description": "Code verifier for PKCE",
+            "type": "string",
+          },
+        },
+        "required": [
+          "authorization_url",
+        ],
+        "type": "object",
+      },
+      "connect_output": {
+        "properties": {
+          "code": {
+            "description": "OAuth2 authorization code used for token exchange",
+            "type": "string",
+          },
+          "code_verifier": {
+            "description": "Code verifier for PKCE from the connect input",
+            "type": "string",
+          },
+          "state": {
+            "description": "OAuth2 state",
+            "type": "string",
+          },
+        },
+        "required": [
+          "code",
+          "state",
+        ],
+        "type": "object",
+      },
+      "connection_settings": {
+        "properties": {
+          "oauth": {
+            "properties": {
+              "created_at": {
+                "type": "string",
+              },
+              "credentials": {
+                "description": "Output of the postConnect hook for oauth2 connectors",
+                "properties": {
+                  "access_token": {
+                    "type": "string",
+                  },
+                  "client_id": {
+                    "description": "Client ID used for the connection",
+                    "type": "string",
+                  },
+                  "expires_at": {
+                    "type": "string",
+                  },
+                  "expires_in": {
+                    "type": "number",
+                  },
+                  "raw": {
+                    "additionalProperties": {},
+                    "type": "object",
+                  },
+                  "refresh_token": {
+                    "type": "string",
+                  },
+                  "scope": {
+                    "type": "string",
+                  },
+                  "token_type": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "access_token",
+                  "scope",
+                  "raw",
+                ],
+                "type": "object",
+              },
+              "last_fetched_at": {
+                "type": "string",
+              },
+              "metadata": {
+                "additionalProperties": {},
+                "type": [
+                  "object",
+                  "null",
+                ],
+              },
+              "updated_at": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "required": [
+          "oauth",
+        ],
+        "type": "object",
+      },
+      "connector_config": {
+        "properties": {
+          "oauth": {
+            "description": "Base oauth configuration for the connector",
+            "properties": {
+              "client_id": {
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "client_secret": {
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "redirect_uri": {
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "scopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": [
+                  "array",
+                  "null",
+                ],
+              },
+            },
+            "type": [
+              "object",
+              "null",
+            ],
+            "ui:field": "OAuthField",
+          },
+        },
+        "required": [
+          "oauth",
+        ],
+        "type": "object",
+      },
+      "integration_data": {
+        "additionalProperties": false,
+        "type": "object",
+      },
+      "pre_connect_input": {
+        "properties": {
+          "connection_id": {
+            "description": "In case of re-connecting, id of the existing connection",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "webhook_input": {
+        "additionalProperties": false,
+        "type": "object",
+      },
+    },
+    "scopes": [
+      {
+        "description": "Read profile information",
+        "scope": "read:profile",
+      },
+      {
+        "description": "Read posts",
+        "scope": "write:posts",
+      },
+    ],
+    "stage": "ga",
+  },
+  {
+    "authType": "OAUTH2",
     "display_name": "Aircall (OAuth)",
     "logo_url": "https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-aircall.svg",
     "name": "aircall",
@@ -1179,194 +1367,6 @@ exports[`db: pglite list connectors with schemas 1`] = `
       {
         "description": "Allows generating webhook URLs for a channel, enabling posting messages as the webhook. This is a channel-specific write permission.",
         "scope": "webhook.incoming",
-      },
-    ],
-    "stage": "ga",
-  },
-  {
-    "authType": "OAUTH2",
-    "display_name": "Dummy OAuth2",
-    "logo_url": "https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-dummy-oauth2.svg",
-    "name": "dummy-oauth2",
-    "openint_scopes": [
-      "read:profile",
-    ],
-    "platforms": undefined,
-    "schemas": {
-      "connect_input": {
-        "properties": {
-          "authorization_url": {
-            "description": "URL to take user to for approval",
-            "type": "string",
-          },
-          "code_verifier": {
-            "description": "Code verifier for PKCE",
-            "type": "string",
-          },
-        },
-        "required": [
-          "authorization_url",
-        ],
-        "type": "object",
-      },
-      "connect_output": {
-        "properties": {
-          "code": {
-            "description": "OAuth2 authorization code used for token exchange",
-            "type": "string",
-          },
-          "code_verifier": {
-            "description": "Code verifier for PKCE from the connect input",
-            "type": "string",
-          },
-          "state": {
-            "description": "OAuth2 state",
-            "type": "string",
-          },
-        },
-        "required": [
-          "code",
-          "state",
-        ],
-        "type": "object",
-      },
-      "connection_settings": {
-        "properties": {
-          "oauth": {
-            "properties": {
-              "created_at": {
-                "type": "string",
-              },
-              "credentials": {
-                "description": "Output of the postConnect hook for oauth2 connectors",
-                "properties": {
-                  "access_token": {
-                    "type": "string",
-                  },
-                  "client_id": {
-                    "description": "Client ID used for the connection",
-                    "type": "string",
-                  },
-                  "expires_at": {
-                    "type": "string",
-                  },
-                  "expires_in": {
-                    "type": "number",
-                  },
-                  "raw": {
-                    "additionalProperties": {},
-                    "type": "object",
-                  },
-                  "refresh_token": {
-                    "type": "string",
-                  },
-                  "scope": {
-                    "type": "string",
-                  },
-                  "token_type": {
-                    "type": "string",
-                  },
-                },
-                "required": [
-                  "access_token",
-                  "scope",
-                  "raw",
-                ],
-                "type": "object",
-              },
-              "last_fetched_at": {
-                "type": "string",
-              },
-              "metadata": {
-                "additionalProperties": {},
-                "type": [
-                  "object",
-                  "null",
-                ],
-              },
-              "updated_at": {
-                "type": "string",
-              },
-            },
-            "type": "object",
-          },
-        },
-        "required": [
-          "oauth",
-        ],
-        "type": "object",
-      },
-      "connector_config": {
-        "properties": {
-          "oauth": {
-            "description": "Base oauth configuration for the connector",
-            "properties": {
-              "client_id": {
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
-              "client_secret": {
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
-              "redirect_uri": {
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
-              "scopes": {
-                "items": {
-                  "type": "string",
-                },
-                "type": [
-                  "array",
-                  "null",
-                ],
-              },
-            },
-            "type": [
-              "object",
-              "null",
-            ],
-            "ui:field": "OAuthField",
-          },
-        },
-        "required": [
-          "oauth",
-        ],
-        "type": "object",
-      },
-      "integration_data": {
-        "additionalProperties": false,
-        "type": "object",
-      },
-      "pre_connect_input": {
-        "properties": {
-          "connection_id": {
-            "description": "In case of re-connecting, id of the existing connection",
-            "type": "string",
-          },
-        },
-        "type": "object",
-      },
-      "webhook_input": {
-        "additionalProperties": false,
-        "type": "object",
-      },
-    },
-    "scopes": [
-      {
-        "description": "Read profile information",
-        "scope": "read:profile",
-      },
-      {
-        "description": "Read posts",
-        "scope": "write:posts",
       },
     ],
     "stage": "ga",

--- a/packages/api-v1/routers/connect.spec.ts
+++ b/packages/api-v1/routers/connect.spec.ts
@@ -56,7 +56,7 @@ const _oauth2Server = createOAuth2Server({
   authCodes: [],
 })
 
-const oauth2Server = new Elysia({prefix: '/api/dummy-oauth2'}).use(
+const oauth2Server = new Elysia({prefix: '/api/acme-oauth2'}).use(
   _oauth2Server,
 )
 
@@ -87,7 +87,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
   describeMaybeOnly('oauth2', () => {
     const ccfgRes = $test('create connector config', async () => {
       const res = await asUser.createConnectorConfig({
-        connector_name: 'dummy-oauth2',
+        connector_name: 'acme-oauth2',
         // TODO: Ensure discriminated union for this.
         config: {oauth: configOauth},
       })
@@ -95,7 +95,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
       expect(res).toMatchObject({
         id: expect.any(String),
         org_id: 'org_222',
-        connector_name: 'dummy-oauth2',
+        connector_name: 'acme-oauth2',
       })
 
       const parsed = oauth2Schemas.connector_config.parse(res.config)
@@ -158,7 +158,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
     // use access token to do something useful, like introspect
     test('introspect token', async () => {
       const res = await oauth2Server.handle(
-        new Request('http://localhost/api/dummy-oauth2/token/introspect', {
+        new Request('http://localhost/api/acme-oauth2/token/introspect', {
           method: 'POST',
           body: new URLSearchParams({
             token:

--- a/packages/ui-v1/__stories__/ConnectionSettingsForm.stories.tsx
+++ b/packages/ui-v1/__stories__/ConnectionSettingsForm.stories.tsx
@@ -37,8 +37,8 @@ const meta: Meta<typeof FormWrapper> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const dummyOauth2ConnectionSettings: Story = {
-  args: {name: 'dummy-oauth2'},
+export const acmeOauth2ConnectionSettings: Story = {
+  args: {name: 'acme-oauth2'},
 }
 
 export const sharepointonlineConnectionSettings: Story = {

--- a/packages/ui-v1/__stories__/ConnectorCard.stories.tsx
+++ b/packages/ui-v1/__stories__/ConnectorCard.stories.tsx
@@ -29,8 +29,8 @@ const meta: Meta<typeof StoryWrapper> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const dummyOauth2ConnectorCard: Story = {
-  args: {name: 'dummy-oauth2'},
+export const acmeOauth2ConnectorCard: Story = {
+  args: {name: 'acme-oauth2'},
 }
 
 export const sharepointonlineConnectorCard: Story = {

--- a/packages/ui-v1/__stories__/ConnectorConfigForm.stories.tsx
+++ b/packages/ui-v1/__stories__/ConnectorConfigForm.stories.tsx
@@ -37,8 +37,8 @@ const meta: Meta<typeof FormWrapper> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const dummyOauth2ConnectorConfig: Story = {
-  args: {name: 'dummy-oauth2'},
+export const acmeOauth2ConnectorConfig: Story = {
+  args: {name: 'acme-oauth2'},
 }
 
 export const sharepointonlineConnectorConfig: Story = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed `dummy-oauth2` connector to `acme-oauth2` across the codebase, updating configurations, schemas, and test references accordingly.
> 
>   - **Renaming**:
>     - Rename `dummy-oauth2` to `acme-oauth2` in `connectors.meta.ts`, `acme-oauth2.ts`, and `openapi.json`.
>     - Update references in `connect.spec.ts` and `connector.spec.ts.snap` to use `acme-oauth2`.
>   - **Schema and Config Updates**:
>     - Update OAuth2 configurations and schemas in `openapi.json` and `openapi.types.ts` to reflect `acme-oauth2`.
>     - Ensure all test cases in `connect.spec.ts` use the new `acme-oauth2` configuration.
>   - **Miscellaneous**:
>     - Remove references to `dummy-oauth2` in various schema and config files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 5e4b1a6a94185403cb450715cafc5d20761f41a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->