### PR TITLE
Update sharepoint and linkedin scopes

### DIFF
--- a/connectors/cnext/json-defs/linkedin.ts
+++ b/connectors/cnext/json-defs/linkedin.ts
@@ -23,7 +23,7 @@ export default {
       {
         scope: 'openid',
         description:
-          "Provides access to the member's basic profile information including name, photo, headline, and current positions.",
+          'Enables user authentication and allows the application to receive a unique identifier for the user. This scope is required for OpenID Connect authentication flows and provides basic identity information about the authenticated user.',
       },
       {
         scope: 'r_basicprofile',

--- a/connectors/cnext/json-defs/linkedin.ts
+++ b/connectors/cnext/json-defs/linkedin.ts
@@ -13,12 +13,17 @@ export default {
     token_request_url: 'https://www.linkedin.com/oauth/v2/accessToken',
     scope_separator: ' ',
     params_config: {},
-    openint_scopes: ['r_liteprofile'],
+    openint_scopes: ['profile', 'email', 'openid'],
     scopes: [
       {
-        scope: 'r_liteprofile',
+        scope: 'profile',
         description:
           "Provides access to the member's basic profile information including name, photo, headline, and current positions. This is a limited subset of profile data compared to 'r_basicprofile'.",
+      },
+      {
+        scope: 'openid',
+        description:
+          "Provides access to the member's basic profile information including name, photo, headline, and current positions.",
       },
       {
         scope: 'r_basicprofile',
@@ -26,7 +31,7 @@ export default {
           "Provides access to the member's full basic profile including experience, education, skills, and recommendations. More extensive than 'r_liteprofile' but doesn't include sensitive information.",
       },
       {
-        scope: 'r_emailaddress',
+        scope: 'email',
         description:
           "Provides access to the member's primary email address. Requires explicit member consent as it's considered sensitive information.",
       },

--- a/connectors/cnext/json-defs/sharepoint.ts
+++ b/connectors/cnext/json-defs/sharepoint.ts
@@ -21,12 +21,17 @@ export default {
       },
       token: {grant_type: 'authorization_code'},
     },
-    openint_scopes: ['offline_access'],
+    openint_scopes: ['offline_access', 'openid'],
     scopes: [
       {
         scope: 'offline_access',
         description:
           'Allows the application to request refresh tokens, which can be used to obtain new access tokens without user interaction. This enables the application to maintain access to resources even when the user is not actively using the application.',
+      },
+      {
+        scope: 'openid',
+        description:
+          'Enables user authentication and allows the application to receive a unique identifier for the user. This scope is required for OpenID Connect authentication flows and provides basic identity information about the authenticated user.',
       },
     ],
   },

--- a/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
+++ b/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
@@ -5172,16 +5172,16 @@ exports[`db: pglite list connectors with schemas 1`] = `
         "scope": "profile",
       },
       {
+        "description": "Enables user authentication and allows the application to receive a unique identifier for the user. This scope is required for OpenID Connect authentication flows and provides basic identity information about the authenticated user.",
+        "scope": "openid",
+      },
+      {
         "description": "Provides access to the member's full basic profile including experience, education, skills, and recommendations. More extensive than 'r_liteprofile' but doesn't include sensitive information.",
         "scope": "r_basicprofile",
       },
       {
         "description": "Provides access to the member's primary email address. Requires explicit member consent as it's considered sensitive information.",
         "scope": "email",
-      },
-      {
-        "description": "Enables user authentication and allows the application to receive a unique identifier for the user. This scope is required for OpenID Connect authentication flows and provides basic identity information about the authenticated user.",
-        "scope": "openid",
       },
       {
         "description": "Allows the application to post, comment, and like posts on behalf of the member. Also enables sharing content to LinkedIn.",

--- a/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
+++ b/packages/api-v1/routers/__snapshots__/connector.spec.ts.snap
@@ -4994,7 +4994,9 @@ exports[`db: pglite list connectors with schemas 1`] = `
     "logo_url": "https://cdn.jsdelivr.net/gh/openintegrations/openint@main/apps/web/public/_assets/logo-linkedin.svg",
     "name": "linkedin",
     "openint_scopes": [
-      "r_liteprofile",
+      "profile",
+      "email",
+      "openid",
     ],
     "platforms": undefined,
     "schemas": {
@@ -5167,7 +5169,7 @@ exports[`db: pglite list connectors with schemas 1`] = `
     "scopes": [
       {
         "description": "Provides access to the member's basic profile information including name, photo, headline, and current positions. This is a limited subset of profile data compared to 'r_basicprofile'.",
-        "scope": "r_liteprofile",
+        "scope": "profile",
       },
       {
         "description": "Provides access to the member's full basic profile including experience, education, skills, and recommendations. More extensive than 'r_liteprofile' but doesn't include sensitive information.",
@@ -5175,7 +5177,11 @@ exports[`db: pglite list connectors with schemas 1`] = `
       },
       {
         "description": "Provides access to the member's primary email address. Requires explicit member consent as it's considered sensitive information.",
-        "scope": "r_emailaddress",
+        "scope": "email",
+      },
+      {
+        "description": "Enables user authentication and allows the application to receive a unique identifier for the user. This scope is required for OpenID Connect authentication flows and provides basic identity information about the authenticated user.",
+        "scope": "openid",
       },
       {
         "description": "Allows the application to post, comment, and like posts on behalf of the member. Also enables sharing content to LinkedIn.",
@@ -7371,6 +7377,7 @@ exports[`db: pglite list connectors with schemas 1`] = `
     "name": "sharepointonline",
     "openint_scopes": [
       "offline_access",
+      "openid",
     ],
     "platforms": undefined,
     "schemas": {
@@ -7544,6 +7551,10 @@ exports[`db: pglite list connectors with schemas 1`] = `
       {
         "description": "Allows the application to request refresh tokens, which can be used to obtain new access tokens without user interaction. This enables the application to maintain access to resources even when the user is not actively using the application.",
         "scope": "offline_access",
+      },
+      {
+        "description": "Enables user authentication and allows the application to receive a unique identifier for the user. This scope is required for OpenID Connect authentication flows and provides basic identity information about the authenticated user.",
+        "scope": "openid",
       },
     ],
     "stage": "ga",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update LinkedIn and SharePoint OAuth scopes to include `openid` and rename existing scopes for better alignment.
> 
>   - **LinkedIn Scopes**:
>     - Update `openint_scopes` in `linkedin.ts` from `r_liteprofile` to `profile`, `email`, `openid`.
>     - Change `scopes` in `linkedin.ts` from `r_liteprofile` to `profile`, `r_emailaddress` to `email`, and add `openid`.
>   - **SharePoint Scopes**:
>     - Update `openint_scopes` in `sharepoint.ts` to include `openid`.
>     - Add `openid` to `scopes` in `sharepoint.ts`.
>   - **Snapshot Updates**:
>     - Update `connector.spec.ts.snap` to reflect new scope changes for LinkedIn and SharePoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for e1c0d732139dd2ce395771a1681db962ba747c68. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->