### PR TITLE
overflow fix - OINT-1184

### DIFF
--- a/packages/ui-v1/components/DataTable.tsx
+++ b/packages/ui-v1/components/DataTable.tsx
@@ -165,7 +165,7 @@ export function DataTableTable(props: {className?: string}) {
     useDataTableContext()
 
   return (
-    <div className={cn('rounded-md border', props.className)}>
+    <div className={cn('overflow-hidden rounded-md border', props.className)}>
       <Table className="w-full">
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `overflow-hidden` to `DataTableTable` to prevent content overflow.
> 
>   - **UI Fix**:
>     - Add `overflow-hidden` to the `div` in `DataTableTable` to prevent content overflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 5525e5f9798b3962c53699fa57ba6b0799fe8e83. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->