### PR TITLE
OINT-1212: Fix connection count in ccfgs api

### DIFF
--- a/packages/api-v1/trpc/routers/connectorConfig.spec.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.spec.ts
@@ -1,5 +1,6 @@
 import type {CustomerId, Viewer} from '@openint/cdk'
 
+import {schema} from '@openint/db'
 import {describeEachDatabase} from '@openint/db/__tests__/test-utils'
 import {getTestTRPCClient} from '../../__tests__/test-utils'
 import {routerContextFromViewer} from '../context'
@@ -101,6 +102,23 @@ describeEachDatabase({drivers: ['pglite'], migrate: true, logger}, (db) => {
     })
     expect(res2.items[0]?.connector).toBeDefined()
     expect(res2.items[0]?.connector?.schemas).toBeDefined()
+  })
+
+  test('list connector config with expanded connection_count', async () => {
+    const res = await asOrg.listConnectorConfigs({
+      expand: ['connection_count'],
+    })
+    const connector_config_id = res.items[0]?.id ?? ''
+    await db.insert(schema.connection).values({
+      connector_config_id,
+      settings: {},
+      disabled: false,
+    })
+    const res2 = await asOrg.listConnectorConfigs({
+      expand: ['connection_count'],
+    })
+    expect(res2.items[0]?.connection_count).toEqual(1)
+    expect(res2.items[1]?.connection_count).toEqual(0)
   })
 
   test('list connector config via custom client', async () => {

--- a/packages/api-v1/trpc/routers/connectorConfig.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.ts
@@ -57,10 +57,9 @@ export const connectorConfigRouter = router({
             SELECT
               COUNT(*)
             FROM
-              ${schema.connection}
+              ${schema.connection} AS conn
             WHERE
-              ${schema.connection}.connector_config_id = ${schema
-            .connector_config.id}
+              conn.connector_config_id = "connector_config"."id"::text
           )
         `.as('connection_count'),
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes connection count calculation in `listConnectorConfigs` and adds a test to verify it.
> 
>   - **Behavior**:
>     - Fixes connection count calculation in `listConnectorConfigs` in `connectorConfig.ts` by modifying SQL query to use `conn.connector_config_id`.
>     - Adds test `list connector config with expanded connection_count` in `connectorConfig.spec.ts` to verify correct connection count.
>   - **Misc**:
>     - Imports `schema` from `@openint/db` in `connectorConfig.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for a1465e2afa699b09c954c9a5a59172500ab04980. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->