### PR TITLE
OINT-1211: Update formatConnection to complete missing data

### DIFF
--- a/connectors/all-connectors/connectors.meta.ts
+++ b/connectors/all-connectors/connectors.meta.ts
@@ -399,7 +399,8 @@ export default {
       logoUrl: '/_assets/logo-plaid.svg',
     },
   },
-  postgres: {
+  // TODO: If postgres is not supported, remove it?
+  /*   postgres: {
     hasClient: false,
     hasServer: true,
     metadata: {
@@ -407,7 +408,7 @@ export default {
       logoUrl: '/_assets/logo-postgres.svg',
       stage: 'ga',
     },
-  },
+  }, */
   quickbooks: {
     hasClient: false,
     hasServer: false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances `formatConnection` to fill missing data using defaults and comments out `postgres` connector in `connectors.meta.ts`.
> 
>   - **Behavior**:
>     - Updates `formatConnection` in `connection.models.ts` to fill missing data using `insertValueToObject()`.
>     - Uses `defaultValueLookup` and existing `connection.settings` to populate missing fields.
>   - **Connectors**:
>     - Comments out `postgres` connector in `connectors.meta.ts` with a TODO note for potential removal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 321dc2d5c2a562a323060644f04a641c7f86fb1b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->