### PR TITLE
feat(connect): Limit connections to one except for custom connectors

### DIFF
--- a/apps/web/app/connect/AddConnectionInner.client.tsx
+++ b/apps/web/app/connect/AddConnectionInner.client.tsx
@@ -8,10 +8,13 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from '@tanstack/react-query'
+import {useRouter} from 'next/navigation'
 import React from 'react'
+import {router} from '@openint/api-v1/trpc/_base'
 import {type ConnectorName} from '@openint/api-v1/trpc/routers/connector.models'
 import {Label, toast} from '@openint/shadcn/ui'
 import {ConnectorConfigCard} from '@openint/ui-v1/domain-components/ConnectorConfigCard'
+import {prettyConnectorName} from '@openint/ui-v1/utils'
 import {useTRPC} from '@/lib-client/TRPCApp'
 import {
   ConnectorClientComponents,
@@ -65,6 +68,8 @@ export function AddConnectionInner({
     }),
   )
 
+  const router = useRouter()
+
   const handleConnect = React.useCallback(async () => {
     try {
       setIsConnecting(true)
@@ -100,6 +105,13 @@ export function AddConnectionInner({
       })
 
       // TODO: update local cache state with result from postConnect
+      toast.success(
+        `${postConnectRes.display_name || prettyConnectorName(name)} connected successfully.`,
+      )
+
+      const url = new URL(window.location.href)
+      url.searchParams.set('view', 'manage')
+      router.replace(url.search || `?view=manage`)
       return postConnectRes
     } catch (error) {
       console.error('Error connecting', error)

--- a/apps/web/app/connect/AddConnectionInner.client.tsx
+++ b/apps/web/app/connect/AddConnectionInner.client.tsx
@@ -10,7 +10,6 @@ import {
 } from '@tanstack/react-query'
 import {useRouter} from 'next/navigation'
 import React from 'react'
-import {router} from '@openint/api-v1/trpc/_base'
 import {type ConnectorName} from '@openint/api-v1/trpc/routers/connector.models'
 import {Label, toast} from '@openint/shadcn/ui'
 import {ConnectorConfigCard} from '@openint/ui-v1/domain-components/ConnectorConfigCard'

--- a/apps/web/lib-client/GlobalCommandBarProvider.tsx
+++ b/apps/web/lib-client/GlobalCommandBarProvider.tsx
@@ -161,12 +161,14 @@ function useConnectionCommands() {
   const checkConnection = useMutation(
     trpc.checkConnection.mutationOptions({
       onMutate: (_variables) => {
-        toast.loading('Ensuring connection is still valid...')
+        loadingToastId = toast.loading('Ensuring connection is still valid...')
       },
       onSuccess: () => {
+        toast.dismiss(loadingToastId)
         toast.success('Your connection is still valid!')
       },
       onError: (error) => {
+        toast.dismiss(loadingToastId)
         toast.error(`Connection validation failed: ${error.message}`)
       },
       onSettled: () => {

--- a/apps/web/lib-client/GlobalCommandBarProvider.tsx
+++ b/apps/web/lib-client/GlobalCommandBarProvider.tsx
@@ -135,15 +135,18 @@ function useConnectionCommands() {
 
   const queryClient = useQueryClient()
 
+  let loadingToastId: string | number = ''
   const deleteConnection = useMutation(
     trpc.deleteConnection.mutationOptions({
       onMutate: () => {
-        toast.loading('Deleting connection...')
+        loadingToastId = toast.loading('Deleting connection...')
       },
       onSuccess: () => {
+        toast.dismiss(loadingToastId)
         toast.success('Connection deleted successfully!')
       },
       onError: (error) => {
+        toast.dismiss(loadingToastId)
         toast.error(`Connection deletion failed: ${error.message}`)
       },
       onSettled: () => {

--- a/packages/api-v1/trpc/routers/utils/pagination.ts
+++ b/packages/api-v1/trpc/routers/utils/pagination.ts
@@ -98,8 +98,10 @@ export function applyPaginationAndOrder<
     orderDirection === 'desc' ? desc(orderByColumn) : orderByColumn,
   ) as T
 
-  // Apply pagination
-  modifiedQuery = modifiedQuery.limit(limit).offset(offset) as T
+  // TODO: reenable pagination once we handle it in our clients
+  if (params?.limit) {
+    modifiedQuery = modifiedQuery.limit(limit).offset(offset) as T
+  }
 
   return {query: modifiedQuery, limit, offset}
 }

--- a/packages/ui-v1/utils/connector.ts
+++ b/packages/ui-v1/utils/connector.ts
@@ -1,0 +1,5 @@
+export function prettyConnectorName(connectorName: string) {
+  return connectorName
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}

--- a/packages/ui-v1/utils/dates.ts
+++ b/packages/ui-v1/utils/dates.ts
@@ -18,10 +18,9 @@ export function timeSince(isoDateString: string): string {
   const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
   const diffHours = Math.floor(diffTime / (1000 * 60 * 60))
   const diffMinutes = Math.floor(diffTime / (1000 * 60))
-  const diffSeconds = Math.floor(diffTime / 1000)
 
   if (diffDays > 0) {
-    return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`
+    return `${diffDays} ${diffDays === 1 ? 'yesterday' : 'days'} ago`
   }
   if (diffHours > 0) {
     return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`
@@ -29,5 +28,5 @@ export function timeSince(isoDateString: string): string {
   if (diffMinutes > 0) {
     return `${diffMinutes} ${diffMinutes === 1 ? 'minute' : 'minutes'} ago`
   }
-  return `${diffSeconds} ${diffSeconds === 1 ? 'second' : 'seconds'} ago`
+  return 'just now'
 }

--- a/packages/ui-v1/utils/dates.ts
+++ b/packages/ui-v1/utils/dates.ts
@@ -20,7 +20,7 @@ export function timeSince(isoDateString: string): string {
   const diffMinutes = Math.floor(diffTime / (1000 * 60))
 
   if (diffDays > 0) {
-    return `${diffDays} ${diffDays === 1 ? 'yesterday' : 'days'} ago`
+    return diffDays === 1 ? 'yesterday' : `${diffDays} days ago`
   }
   if (diffHours > 0) {
     return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`

--- a/packages/ui-v1/utils/index.ts
+++ b/packages/ui-v1/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './dates'
+export * from './connector'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Limits connections to one per connector, except for custom connectors, with UI and utility updates for better connection management.
> 
>   - **Behavior**:
>     - Limits connections to one per connector, except for custom connectors, in `AddConnections` in `page.tsx`.
>     - Displays a message when all available integrations are connected.
>     - Redirects to manage view after successful connection in `AddConnectionInner.client.tsx`.
>   - **UI**:
>     - Adds success toast notification in `AddConnectionInner.client.tsx` after connection.
>     - Updates loading and success/error toasts in `GlobalCommandBarProvider.tsx` for connection commands.
>   - **Utilities**:
>     - Adds `prettyConnectorName` function in `connector.ts` for formatting connector names.
>     - Modifies `timeSince` in `dates.ts` to return 'just now' for recent times.
>   - **Misc**:
>     - Temporarily disables pagination in `pagination.ts` until client-side handling is implemented.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for b98b3fe2bc3de62386fddb77e65791cadfb194c8. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->