### PR TITLE
OINT-1225: Show toasts for success/failure actions, show alert on delete ccfg when it has connections, minor improvs

### DIFF
--- a/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
@@ -5,9 +5,15 @@ import type {JSONSchemaFormRef} from '@openint/ui-v1'
 import type {ColumnDef} from '@openint/ui-v1/components/DataTable'
 
 import {useSuspenseQueries} from '@tanstack/react-query'
-import {Plus} from 'lucide-react'
+import {AlertCircle, Plus} from 'lucide-react'
 import {useRef, useState} from 'react'
-import {Button, toast} from '@openint/shadcn/ui'
+import {
+  Button,
+  toast,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@openint/shadcn/ui'
 import {
   Sheet,
   SheetContent,
@@ -333,12 +339,30 @@ export function ConnectorConfigList() {
           {selectedConnector && (
             <SheetFooter className="mt-auto border-t p-4">
               <div className="flex w-full flex-row justify-between">
-                <Button
-                  variant="destructive"
-                  onClick={handleDelete}
-                  disabled={!selectedCcfg || deleteConfig.isPending}>
-                  {deleteConfig.isPending ? 'Deleting...' : 'Delete'}
-                </Button>
+                <div className="flex flex-row items-center gap-2">
+                  {selectedCcfg?.connection_count ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <AlertCircle className="text-destructive size-4" />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Cannot delete connector config because it has active
+                        connections, delete the connections before deleting the
+                        connector config.
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : null}
+                  <Button
+                    variant="destructive"
+                    onClick={handleDelete}
+                    disabled={
+                      !selectedCcfg ||
+                      deleteConfig.isPending ||
+                      (selectedCcfg.connection_count ?? 0) > 0
+                    }>
+                    {deleteConfig.isPending ? 'Deleting...' : 'Delete'}
+                  </Button>
+                </div>
                 <Button
                   onClick={handleFormSubmit}
                   disabled={createConfig.isPending || updateConfig.isPending}>

--- a/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
@@ -88,10 +88,10 @@ export function ConnectorConfigList() {
     : {}
 
   const formContext = {
-    connectorName: selectedConnector?.display_name ?? '',
     openint_scopes: selectedConnector?.openint_scopes ?? [],
     scopes: selectedConnector?.scopes ?? [],
     initialData: selectedCcfg,
+    connector: selectedConnector,
   }
 
   const columns: Array<
@@ -237,6 +237,16 @@ export function ConnectorConfigList() {
       // TODO: We need to show a toast here
     }
   }
+
+  const saveButtonLabel =
+    createConfig.isPending || updateConfig.isPending
+      ? selectedCcfg
+        ? 'Updating...'
+        : 'Creating...'
+      : selectedCcfg
+        ? `Edit ${selectedConnector?.display_name} Connector`
+        : `Create ${selectedConnector?.display_name} Connector`
+
   // initial flash of no data....
   if (!res.data.items || !connectorRes.data.items) {
     return null
@@ -286,7 +296,7 @@ export function ConnectorConfigList() {
           <div className="p-4 pb-0">
             <SheetHeader>
               <SheetTitle className="text-lg">
-                {selectedConnector ? 'Edit Connector' : 'Add Connector'}
+                {selectedCcfg ? 'Edit Connector' : 'Add Connector'}
               </SheetTitle>
             </SheetHeader>
           </div>
@@ -322,9 +332,7 @@ export function ConnectorConfigList() {
                 <Button
                   onClick={handleFormSubmit}
                   disabled={createConfig.isPending || updateConfig.isPending}>
-                  {createConfig.isPending || updateConfig.isPending
-                    ? 'Saving...'
-                    : 'Save'}
+                  {saveButtonLabel}
                 </Button>
               </div>
             </SheetFooter>

--- a/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
@@ -7,7 +7,7 @@ import type {ColumnDef} from '@openint/ui-v1/components/DataTable'
 import {useSuspenseQueries} from '@tanstack/react-query'
 import {Plus} from 'lucide-react'
 import {useRef, useState} from 'react'
-import {Button} from '@openint/shadcn/ui'
+import {Button, toast} from '@openint/shadcn/ui'
 import {
   Sheet,
   SheetContent,
@@ -184,7 +184,7 @@ export function ConnectorConfigList() {
 
     try {
       if (selectedCcfg) {
-        await updateConfig.mutateAsync({
+        const res = await updateConfig.mutateAsync({
           id: selectedCcfg.id,
           display_name: displayName,
           disabled,
@@ -193,8 +193,9 @@ export function ConnectorConfigList() {
             ...rest,
           },
         })
+        toast.success(`Connector ${res.id} updated successfully`)
       } else {
-        await createConfig.mutateAsync({
+        const res = await createConfig.mutateAsync({
           connector_name: selectedConnector.name,
           display_name: displayName,
           disabled,
@@ -203,6 +204,7 @@ export function ConnectorConfigList() {
             ...rest,
           },
         })
+        toast.success(`Connector ${res.id} created successfully`)
       }
 
       setSheetOpen(false)
@@ -210,7 +212,9 @@ export function ConnectorConfigList() {
       setSelectedCcfg(null)
       await res.refetch()
     } catch (error) {
-      console.error('Error saving configuration:', error)
+      toast.error(
+        `Failed to save connector configuration: ${error instanceof Error ? error.message : error}`,
+      )
     }
   }
 
@@ -231,10 +235,12 @@ export function ConnectorConfigList() {
       setSheetOpen(false)
       setSelectedConnector(null)
       setSelectedCcfg(null)
+      toast.success(`Connector config ${selectedCcfg?.id} deleted successfully`)
       await res.refetch()
     } catch (error) {
-      console.error('Failed to delete connector config:', error)
-      // TODO: We need to show a toast here
+      toast.error(
+        `Failed to delete connector config ${selectedCcfg?.id}: ${error instanceof Error ? error.message : error}`,
+      )
     }
   }
 

--- a/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/page.client.tsx
@@ -290,10 +290,14 @@ export function ConnectorConfigList() {
       <Sheet
         open={sheetOpen}
         onOpenChange={(open) => {
-          setSheetOpen(open)
-          if (!open) {
+          if (selectedConnector && !selectedCcfg) {
+            setSelectedConnector(null)
+          } else if (selectedCcfg) {
             setSelectedConnector(null)
             setSelectedCcfg(null)
+            setSheetOpen(open)
+          } else {
+            setSheetOpen(open)
           }
         }}>
         <SheetContent

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -1,7 +1,8 @@
 import type {FieldProps, RegistryFieldsType} from '@rjsf/utils'
-import type {ConnectorConfig} from '@openint/api-v1/models'
+import type {ConnectorConfig, Core} from '@openint/api-v1/models'
 import type {OAuthConnectorConfig} from '@openint/cnext/auth-oauth2/schemas'
 
+import Image from 'next/image'
 import {useState} from 'react'
 import {env} from '@openint/env'
 import {Input, Switch} from '@openint/shadcn/ui'
@@ -19,13 +20,13 @@ interface Scope {
 interface OAuthFormContext {
   openint_scopes: string[]
   scopes: Scope[]
-  connectorName: string
   initialData: ConnectorConfig
+  connector: Core['connector']
 }
 
 export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
   const {formData, onChange, formContext} = props
-  const {openint_scopes, scopes, connectorName, initialData} =
+  const {openint_scopes, scopes, initialData, connector} =
     formContext as OAuthFormContext
 
   const scopeLookup =
@@ -73,7 +74,7 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
         <label
           htmlFor="use-openint-credentials"
           className="text-sm font-medium text-gray-700">
-          Use OpenInt {connectorName} credentials
+          Use OpenInt {connector?.display_name} credentials
         </label>
         <Switch
           id="use-openint-credentials"
@@ -157,27 +158,29 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
 
 export function DisabledField(props: FieldProps<boolean>) {
   const {formData, onChange, formContext} = props
-  const {initialData, connectorName} = formContext as OAuthFormContext
+  const {initialData, connector} = formContext as OAuthFormContext
 
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-2 space-y-1">
         <div className="flex items-center gap-2">
-          {initialData?.connector?.logo_url && (
-            <img
-              src={initialData.connector.logo_url}
-              alt={`${connectorName} logo`}
-              className="h-6 w-6 object-contain"
+          {connector?.logo_url && (
+            <Image
+              src={connector.logo_url}
+              alt={`${connector.display_name} logo`}
+              width={24}
+              height={24}
+              className="object-contain"
             />
           )}
-          <h3 className="font-medium">{connectorName}</h3>
+          <h3 className="font-medium">{connector?.display_name}</h3>
         </div>
         {initialData?.id && <CopyID value={initialData?.id} />}
 
         <div className="flex items-center space-x-2 text-sm">
           <ConnectorBadges
-            stage={initialData?.connector?.stage}
-            platforms={initialData?.connector?.platforms}
+            stage={connector?.stage}
+            platforms={connector?.platforms}
           />
         </div>
       </div>

--- a/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/CredentialsField.tsx
@@ -1,5 +1,5 @@
 import type {FieldProps} from '@rjsf/utils'
-import type {ConnectorConfig} from '@openint/api-v1/models'
+import type {ConnectorConfig, Core} from '@openint/api-v1/models'
 
 import {useState} from 'react'
 import {Input} from '@openint/shadcn/ui/input'
@@ -12,7 +12,7 @@ type Credentials = {
 } | null
 
 interface CredentialsFormContext {
-  connectorName: string
+  connector: Core['connector']
   initialData: ConnectorConfig
 }
 
@@ -23,7 +23,7 @@ export function CredentialsField<T extends Credentials = Credentials>(
   props: FieldProps<T>,
 ) {
   const {formData, onChange, formContext} = props
-  const {connectorName, initialData} = formContext as CredentialsFormContext
+  const {connector, initialData} = formContext as CredentialsFormContext
   const [useOpenIntCredentials, setUseOpenIntCredentials] = useState(
     !formData?.clientId && !formData?.clientSecret,
   )
@@ -53,7 +53,7 @@ export function CredentialsField<T extends Credentials = Credentials>(
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Label>Use OpenInt {connectorName} credentials</Label>
+        <Label>Use OpenInt {connector?.display_name} credentials</Label>
         <Switch
           checked={useOpenIntCredentials}
           onCheckedChange={handleSwitchChange}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds toast notifications for connector config actions, disables delete for active connections, and updates UI components for better feedback.
> 
>   - **Behavior**:
>     - Adds toast notifications for success and failure in `handleSave` and `handleDelete` in `page.client.tsx`.
>     - Shows tooltip and disables delete button if connector config has active connections in `ConnectorConfigList` in `page.client.tsx`.
>   - **UI Components**:
>     - Updates `OAuthField` and `DisabledField` in `fields.tsx` to use `connector.display_name` instead of `connectorName`.
>     - Updates `CredentialsField` in `CredentialsField.tsx` to use `connector.display_name` and handle credential toggling.
>   - **Misc**:
>     - Refactors `saveButtonLabel` logic in `page.client.tsx` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 327b2f4c2fc88ef754bd3a0d4e429bdefd3da8cf. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->