### PR TITLE
fix(api): Coerce array query params

### DIFF
--- a/packages/api-v1/__tests__/sdk.spec.ts
+++ b/packages/api-v1/__tests__/sdk.spec.ts
@@ -78,7 +78,7 @@ describeEachDatabase({drivers: ['pglite'], migrate: true}, (db) => {
       await expect(wrongTokenClient.getCurrentUser()).rejects.toThrow()
     })
 
-    test('enum string array should work ', async () => {
+    test('enum string array should work', async () => {
       const baseUrl = 'http://localhost/v1'
       const assertFetchSdk = new Openint({
         apiKey,

--- a/packages/api-v1/package.json
+++ b/packages/api-v1/package.json
@@ -19,7 +19,7 @@
     "@openint/env": "workspace:*",
     "@openint/events": "workspace:*",
     "@openint/oauth2": "workspace:*",
-    "@openint/sdk": "0.1.0-alpha.20",
+    "@openint/sdk": "latest",
     "@openint/util": "workspace:*",
     "@trpc/server": "^11.0.1",
     "drizzle-zod": "^0.7.0",

--- a/packages/api-v1/trpc/routers/connect.models.ts
+++ b/packages/api-v1/trpc/routers/connect.models.ts
@@ -1,5 +1,5 @@
 import {zCustomerId} from '@openint/cdk'
-import {z, zCoerceBoolean} from '@openint/util/zod-utils'
+import {z, zCoerceArray, zCoerceBoolean} from '@openint/util/zod-utils'
 import {zConnectorName} from './connector.models'
 
 export const zConnectOptions = z.object({
@@ -9,7 +9,7 @@ export const zConnectOptions = z.object({
     description:
       'Optional URL to return customers after adding a connection or if they press the Return To Organization button',
   }),
-  connector_names: z.array(zConnectorName).optional().openapi({
+  connector_names: zCoerceArray(zConnectorName).optional().openapi({
     title: 'Connector Names',
     description:
       'The names of the connectors to show in the connect page. If not provided, all connectors will be shown',

--- a/packages/api-v1/trpc/routers/connection.ts
+++ b/packages/api-v1/trpc/routers/connection.ts
@@ -8,7 +8,7 @@ import {makeId} from '@openint/cdk'
 import {and, dbUpsertOne, eq, inArray, schema, sql} from '@openint/db'
 import {getBaseURLs} from '@openint/env'
 import {makeUlid} from '@openint/util/id-utils'
-import {z} from '@openint/util/zod-utils'
+import {z, zCoerceArray} from '@openint/util/zod-utils'
 import {authenticatedProcedure, orgProcedure, router} from '../_base'
 import {getApiV1URL} from '../../lib/typed-routes'
 import {core} from '../../models/core'
@@ -44,7 +44,7 @@ export const connectionRouter = router({
         id: zConnectionId,
         include_secrets: zIncludeSecrets.optional().default('none'),
         refresh_policy: zRefreshPolicy.optional().default('auto'),
-        expand: z.array(zConnectionExpandOption).optional().default([]),
+        expand: zCoerceArray(zConnectionExpandOption).optional().default([]),
       }),
     )
     .output(zConnectionExpanded)
@@ -180,7 +180,7 @@ export const connectionRouter = router({
     .input(
       zListParams
         .extend({
-          connector_names: z.array(zConnectorName).optional().openapi({
+          connector_names: zCoerceArray(zConnectorName).optional().openapi({
             description: 'Filter list by connector names',
           }),
           customer_id: zCustomerId.optional().openapi({

--- a/packages/api-v1/trpc/routers/connector.ts
+++ b/packages/api-v1/trpc/routers/connector.ts
@@ -1,7 +1,7 @@
 import type {Z} from '@openint/util/zod-utils'
 
 import {defConnectors} from '@openint/all-connectors/connectors.def'
-import {z} from '@openint/util/zod-utils'
+import {z, zCoerceArray} from '@openint/util/zod-utils'
 import {publicProcedure, router} from '../_base'
 import {core} from '../../models/core'
 import {getConnectorModel, zConnectorName} from './connector.models'
@@ -26,7 +26,9 @@ export const connectorRouter = router({
         summary: 'List Connectors',
       },
     })
-    .input(z.object({expand: z.array(zExpandOption).optional()}).optional())
+    .input(
+      z.object({expand: zCoerceArray(zExpandOption).optional()}).optional(),
+    )
     .output(zListResponse(zConnectorExtended).describe('List of connectors'))
     .query(async ({input}) => {
       const items = Object.values(defConnectors).map((def) =>
@@ -53,7 +55,7 @@ export const connectorRouter = router({
     .input(
       z.object({
         name: zConnectorName,
-        expand: z.array(zExpandOption).optional(),
+        expand: zCoerceArray(zExpandOption).optional(),
       }),
     )
     .output(zConnectorExtended)

--- a/packages/api-v1/trpc/routers/connectorConfig.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.ts
@@ -5,7 +5,7 @@ import {defConnectors} from '@openint/all-connectors/connectors.def'
 import {makeId} from '@openint/cdk'
 import {and, asc, desc, eq, inArray, schema, sql} from '@openint/db'
 import {makeUlid} from '@openint/util/id-utils'
-import {z} from '@openint/util/zod-utils'
+import {z, zCoerceArray} from '@openint/util/zod-utils'
 import {authenticatedProcedure, orgProcedure, router} from '../_base'
 import {
   connectorConfigExtended,
@@ -44,7 +44,7 @@ export const connectorConfigRouter = router({
     .input(
       z.object({
         id: zConnectorConfigId,
-        expand: z.array(zConnectorConfigExpandOption).optional(),
+        expand: zCoerceArray(zConnectorConfigExpandOption).optional(),
       }),
     )
     .output(connectorConfigExtended)
@@ -85,8 +85,8 @@ export const connectorConfigRouter = router({
     .input(
       zListParams
         .extend({
-          expand: z.array(zConnectorConfigExpandOption).optional(),
-          connector_names: z.array(zConnectorName).optional().openapi({
+          expand: zCoerceArray(zConnectorConfigExpandOption).optional(),
+          connector_names: zCoerceArray(zConnectorName).optional().openapi({
             description: 'The names of the connectors to filter by',
           }),
         })

--- a/packages/util/zod-utils.ts
+++ b/packages/util/zod-utils.ts
@@ -301,3 +301,18 @@ export function zCoerceBoolean(params?: Z.RawCreateParams) {
     return Boolean(val)
   }, z.boolean(params))
 }
+
+/**
+ * Coerce a string to an array of values.
+ *
+ * @param schema
+ * @returns
+ */
+export function zCoerceArray<T>(schema: Z.ZodType<T>) {
+  return z.preprocess((val) => {
+    if (typeof val === 'string') {
+      return val.split(',')
+    }
+    return val
+  }, z.array(schema))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,8 +973,8 @@ importers:
         specifier: workspace:*
         version: link:../oauth2
       '@openint/sdk':
-        specifier: 0.1.0-alpha.20
-        version: 0.1.0-alpha.20
+        specifier: 1.5.0
+        version: 1.5.0
       '@openint/util':
         specifier: workspace:*
         version: link:../util
@@ -3312,8 +3312,8 @@ packages:
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
 
-  '@openint/sdk@0.1.0-alpha.20':
-    resolution: {integrity: sha512-KDpKbTXZOfrmk+o66NXnne7BoyIKVFSkiWbtARQ/lFzgF1XE06qj4X2pQJ8z64x0xeXtYnSH/DGSXPsOjGAOpQ==}
+  '@openint/sdk@1.5.0':
+    resolution: {integrity: sha512-dC89Tpi4WFf0c07m71tNokiVyKQ7Vvbxs61NQR6MBcREedND8+zUK5SFj4JZM+YXeanrpYuEhv1fwubNy4AaMg==}
 
   '@opensdks/fetch-links@0.0.18':
     resolution: {integrity: sha512-EhBj92wLXoj3pF4ERxzoEhAlwlefIzQ31At0zaksSbA9zqMlod9DyfypQRX/6J8w4iZzraV33BtFEk7l98nsLA==}
@@ -17100,7 +17100,7 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
 
-  '@openint/sdk@0.1.0-alpha.20': {}
+  '@openint/sdk@1.5.0': {}
 
   '@opensdks/fetch-links@0.0.18': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,7 +973,7 @@ importers:
         specifier: workspace:*
         version: link:../oauth2
       '@openint/sdk':
-        specifier: 1.5.0
+        specifier: latest
         version: 1.5.0
       '@openint/util':
         specifier: workspace:*


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `zCoerceArray` for string to array coercion in query parameters and updates relevant files to use it, with a test added for verification.
> 
>   - **Behavior**:
>     - Introduces `zCoerceArray` in `zod-utils.ts` to coerce string to array for query parameters.
>     - Updates `connector_names` and `expand` parameters to use `zCoerceArray` in `connect.models.ts`, `connection.ts`, `connector.ts`, and `connectorConfig.ts`.
>     - Adds test in `sdk.spec.ts` to verify `connector_names` query parameter handling.
>   - **Dependencies**:
>     - Updates `@openint/sdk` to `latest` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 097c94bb467f2994c3155ed2847c289fa606a3be. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->