### PR TITLE
fix(connect): hardcoding notion to header auth

### DIFF
--- a/connectors/cnext/auth-oauth2/utils.ts
+++ b/connectors/cnext/auth-oauth2/utils.ts
@@ -90,7 +90,7 @@ export function getClient({
       revokeUrl: oauthConfig.revocation_request_url,
       scopeDelimiter: oauthConfig.scope_separator,
       paramKeyMapping: oauthConfig.params_config.param_names,
-      clientAuthLocation: 'body', // Make this configurable
+      clientAuthLocation: connectorName === 'notion' ? 'header' : 'body', // Make this configurable
     },
     connectCtx.fetch,
   )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `clientAuthLocation` to 'header' for 'notion' connector in `getClient()` in `utils.ts`.
> 
>   - **Behavior**:
>     - In `getClient()` in `utils.ts`, set `clientAuthLocation` to 'header' for 'notion' connector, otherwise 'body'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 77f447817591211f2838bd98f7f87ba6e46d54de. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->