### PR TITLE
chore(oauth): adding required scopes

### DIFF
--- a/connectors/cnext/auth-oauth2/createOAuth2ConnectorServer.ts
+++ b/connectors/cnext/auth-oauth2/createOAuth2ConnectorServer.ts
@@ -7,7 +7,7 @@ import {env, resolveRoute} from '@openint/env'
 import {createCodeVerifier} from '@openint/oauth2/utils.client'
 import {makeUlid} from '@openint/util/id-utils'
 import {zOauthState} from './schemas'
-import {getClient} from './utils'
+import {getClient, getRequestedScopes} from './utils'
 
 /*
  * This function generates a server implementation for an OAuth2 connector.
@@ -72,14 +72,7 @@ export function createOAuth2ConnectorServer<
         redirect_uri:
           config.oauth?.redirect_uri?.trim() ||
           env.NEXT_PUBLIC_OAUTH_REDIRECT_URI_GATEWAY,
-        scopes: config.oauth?.scopes
-          ? // here because some old ccfgs have scopes as a string
-            typeof config.oauth.scopes === 'string'
-            ? (config.oauth.scopes as string).split(
-                oauthConfigTemplate.scope_separator ?? ' ',
-              )
-            : config.oauth.scopes
-          : [],
+        scopes: getRequestedScopes(config, oauthConfig),
         state: JSON.stringify({
           connection_id: connectionId,
           redirect_uri: new URL(

--- a/connectors/cnext/auth-oauth2/schemas.ts
+++ b/connectors/cnext/auth-oauth2/schemas.ts
@@ -159,6 +159,10 @@ export const zOAuthConfig = z.object({
     .url()
     .optional()
     .describe('URL to revoke an access token from the provider'),
+  required_scopes: z
+    .array(z.string())
+    .optional()
+    .describe('Scopes required by the Connector for Oauth requests'),
   openint_scopes: z
     .array(z.string())
     .optional()

--- a/connectors/cnext/auth-oauth2/utils.spec.ts
+++ b/connectors/cnext/auth-oauth2/utils.spec.ts
@@ -121,4 +121,19 @@ describe('getRequestedScopes', () => {
     )
     expect(scopes).toEqual([])
   })
+
+  test('should handle both required_scopes and config.oauth.scopes being undefined', () => {
+    const scopes = getRequestedScopes(
+      {oauth: {scopes: undefined}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        // No required_scopes specified
+      },
+    )
+    expect(scopes).toEqual([])
+  })
 })

--- a/connectors/cnext/auth-oauth2/utils.spec.ts
+++ b/connectors/cnext/auth-oauth2/utils.spec.ts
@@ -1,0 +1,124 @@
+import {describe, expect, test} from '@jest/globals'
+import {getRequestedScopes} from './utils'
+
+describe('getRequestedScopes', () => {
+  test('should return the requested scopes', () => {
+    const scopes = getRequestedScopes(
+      {oauth: {scopes: ['scope1', 'scope2']}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        scope_separator: ' ',
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2'])
+  })
+
+  test('should include required_scopes from oauthConfig', () => {
+    const scopes = getRequestedScopes(
+      {oauth: {scopes: ['scope1', 'scope2']}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        required_scopes: ['scope3', 'scope4'],
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2', 'scope3', 'scope4'])
+  })
+
+  test('should deduplicate scopes that appear in both config and required_scopes', () => {
+    const scopes = getRequestedScopes(
+      {oauth: {scopes: ['scope1', 'scope2', 'scope3']}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        required_scopes: ['scope2', 'scope3', 'scope4'],
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2', 'scope3', 'scope4'])
+  })
+
+  test('should handle config with no scopes', () => {
+    const scopes = getRequestedScopes(
+      {oauth: {}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        required_scopes: ['scope1', 'scope2'],
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2'])
+  })
+
+  test('should handle config with no oauth property', () => {
+    const scopes = getRequestedScopes(
+      {},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        required_scopes: ['scope1', 'scope2'],
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2'])
+  })
+
+  test('should handle scopes as a string with default separator', () => {
+    const scopes = getRequestedScopes(
+      // @ts-expect-error - Testing legacy case where scopes is a string
+      {oauth: {scopes: 'scope1 scope2'}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2'])
+  })
+
+  test('should handle scopes as a string with custom separator', () => {
+    const scopes = getRequestedScopes(
+      // @ts-expect-error - Testing legacy case where scopes is a string
+      {oauth: {scopes: 'scope1,scope2,scope3'}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+        scope_separator: ',',
+      },
+    )
+    expect(scopes).toEqual(['scope1', 'scope2', 'scope3'])
+  })
+
+  test('should work with no required_scopes and no config scopes', () => {
+    const scopes = getRequestedScopes(
+      {oauth: {}},
+      {
+        type: 'OAUTH2',
+        scopes: [],
+        authorization_request_url: 'https://example.com/auth',
+        token_request_url: 'https://example.com/token',
+        params_config: {},
+      },
+    )
+    expect(scopes).toEqual([])
+  })
+})

--- a/connectors/cnext/auth-oauth2/utils.ts
+++ b/connectors/cnext/auth-oauth2/utils.ts
@@ -96,3 +96,22 @@ export function getClient({
   )
   return {client, oauthConfig}
 }
+
+export function getRequestedScopes(
+  config: Z.infer<typeof oauth2Schemas.connector_config>,
+  oauthConfig: Z.infer<typeof zOAuthConfig>,
+) {
+  const scopes = config.oauth?.scopes
+    ? // here because some old ccfgs have scopes as a string
+      typeof config.oauth.scopes === 'string'
+      ? (config.oauth.scopes as string).split(
+          oauthConfig.scope_separator ?? ' ',
+        )
+      : config.oauth.scopes
+    : []
+  const addedRequiredScopes = new Set([
+    ...scopes,
+    ...(oauthConfig.required_scopes || []),
+  ])
+  return Array.from(addedRequiredScopes)
+}

--- a/connectors/cnext/json-defs/hubspot.ts
+++ b/connectors/cnext/json-defs/hubspot.ts
@@ -12,8 +12,13 @@ export default {
     token_request_url: 'https://api.hubapi.com/oauth/v1/token',
     scope_separator: ' ',
     params_config: {},
+    required_scopes: ['oauth'],
     openint_scopes: ['crm.objects.contacts.read'],
     scopes: [
+      {
+        scope: 'oauth',
+        description: "Allows the app to make OAuth requests to HubSpot's API.",
+      },
       {
         scope: 'contacts',
         description:


### PR DESCRIPTION
## **User description**
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `getRequestedScopes()` to handle OAuth2 scopes, updates schema and server logic, and adds tests.
> 
>   - **Behavior**:
>     - Replaces scope handling logic in `createOAuth2ConnectorServer.ts` with `getRequestedScopes()` from `utils.ts`.
>     - `getRequestedScopes()` combines `config.oauth.scopes` and `oauthConfig.required_scopes`, deduplicating them.
>   - **Schemas**:
>     - Adds `required_scopes` to `zOAuthConfig` in `schemas.ts`.
>   - **Tests**:
>     - Adds `utils.spec.ts` to test `getRequestedScopes()` for various cases, including deduplication and handling of string scopes.
>   - **Misc**:
>     - Updates `hubspot.ts` to include `required_scopes` in the OAuth configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 578b4137ba81af22b59a140563f2c8d478882476. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Introduced a new utility function `getRequestedScopes` to merge and deduplicate OAuth scopes from both connector config and schema, supporting legacy string formats and custom separators.
- Updated the OAuth2 connector server logic to use `getRequestedScopes` for determining requested scopes, ensuring consistency and reducing code duplication.
- Extended the OAuth configuration schema (`zOAuthConfig`) to support an optional `required_scopes` property, allowing connectors to specify mandatory scopes.
- Added thorough unit tests for `getRequestedScopes`, covering various edge cases including deduplication, string-based scopes, and missing properties.
- Enhanced the HubSpot connector definition by specifying `required_scopes` and updating scope descriptions.

This PR standardizes and improves how OAuth scopes are handled across connectors, making the process more robust, maintainable, and testable. It also ensures that required scopes are explicitly defined and enforced for OAuth integrations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Add getRequestedScopes utility for merging and deduplicating OAuth <br>scopes</code></dd></summary>
<hr>

connectors/cnext/auth-oauth2/utils.ts
<li>Added a new function <code>getRequestedScopes</code> to combine and deduplicate <br>OAuth scopes from config and schema.<br> <li> Ensures legacy support for string-based scopes with custom separators.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/538/files#diff-a499ab798f7976042eda016ad1e087a1f88d035c22c9f9e89c4dd11090d11f04">+19/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>createOAuth2ConnectorServer.ts</strong><dd><code>Use getRequestedScopes utility in OAuth2 connector server logic</code></dd></summary>
<hr>

connectors/cnext/auth-oauth2/createOAuth2ConnectorServer.ts
<li>Replaced inline scope handling logic with the new <code>getRequestedScopes</code> <br>utility.<br> <li> Simplified and standardized how requested OAuth scopes are determined <br>during authorization.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/538/files#diff-a69d6d4ebb60faacc51a090e8d6f0c30d29d02cc78e59720cd79886ec35c87fe">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schemas.ts</strong><dd><code>Add required_scopes property to OAuth config schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

connectors/cnext/auth-oauth2/schemas.ts
<li>Added an optional <code>required_scopes</code> property to the <code>zOAuthConfig</code> schema.<br> <li> Documented the new property for clarity in OAuth configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/538/files#diff-858beb00fd7bdf4766ce9f49d681878582ce7e3060334bdada76f9cc79503230">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hubspot.ts</strong><dd><code>Add required_scopes to HubSpot OAuth configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

connectors/cnext/json-defs/hubspot.ts
<li>Added <code>required_scopes: ['oauth']</code> to the HubSpot OAuth configuration.<br> <li> Updated the <code>scopes</code> array to include a description for the new required <br>scope.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/538/files#diff-242a3cb4a8c0c87a04a4c4a5338952a8d3caa4bdc8ca2301d785cdd6075accd8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.spec.ts</strong><dd><code>Add tests for getRequestedScopes utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

connectors/cnext/auth-oauth2/utils.spec.ts
<li>Added comprehensive tests for the <code>getRequestedScopes</code> utility.<br> <li> Covered cases for deduplication, legacy string scopes, custom <br>separators, and missing properties.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/538/files#diff-7769c287488b393eb66a490be262174fde6e531100b3b31437796b8f08549ff1">+124/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
