### PR TITLE
oint-1221: On organization dropdown change bring back refresh page content

### DIFF
--- a/apps/web/lib-client/GlobalCommandBarProvider.tsx
+++ b/apps/web/lib-client/GlobalCommandBarProvider.tsx
@@ -8,7 +8,7 @@ import type {
 
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 import {useRouter} from 'next/navigation'
-import React from 'react'
+import React, {useEffect} from 'react'
 import {cmdInit} from '@openint/commands'
 import {
   useOrganization,
@@ -111,7 +111,12 @@ export function useCommandDefinitionMap() {
 }
 
 function useCurrentSessionCommands() {
+  const queryClient = useQueryClient()
   const {userId, orgId} = useSession()
+  useEffect(() => {
+    // Invalidate all queries when the orgId changes
+    void queryClient.invalidateQueries()
+  }, [orgId, queryClient])
 
   return {
     'currentSession:copyUserId': userId && {


### PR DESCRIPTION
## **User description**
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added `useEffect` in `useCurrentSessionCommands` to invalidate queries on `orgId` change, refreshing page content.
> 
>   - **Behavior**:
>     - In `useCurrentSessionCommands`, added `useEffect` to invalidate all queries when `orgId` changes, ensuring page content refreshes on organization change.
>   - **Imports**:
>     - Added `useEffect` import in `GlobalCommandBarProvider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 04a8b68310a04948373213d45e2547c077559990. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Added a `useEffect` hook in `useCurrentSessionCommands` to invalidate all React Query queries whenever the `orgId` changes, ensuring that page content is refreshed when the user switches organizations.
- Imported `useEffect` from React to enable the new effect logic.
- Instantiated `queryClient` using `useQueryClient` to access query invalidation functionality.

This PR ensures that when a user changes their organization, all cached queries are invalidated and the page content is refreshed accordingly. This resolves issues where stale data could be shown after switching organizations, improving the accuracy and responsiveness of the user interface.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GlobalCommandBarProvider.tsx</strong><dd><code>Refresh page content by invalidating queries on organization change</code></dd></summary>
<hr>

apps/web/lib-client/GlobalCommandBarProvider.tsx
<li>Added <code>useEffect</code> to invalidate all queries when <code>orgId</code> changes, ensuring <br>page content is refreshed on organization switch.<br> <li> Imported <code>useEffect</code> from React to support the new effect.<br> <li> Instantiated <code>queryClient</code> using <code>useQueryClient</code> within <br><code>useCurrentSessionCommands</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/550/files#diff-6b510158a449f1ad3177621970c1688b65148cfc998154de12677b9c31ec790c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
