### PR TITLE
oint-1266: If there are no configured CCFG default credentials default to showing client_id and client_secret. The toggle should not be shown

### DIFF
--- a/apps/web/app/connect/ConnectorConnect.client.tsx
+++ b/apps/web/app/connect/ConnectorConnect.client.tsx
@@ -139,7 +139,7 @@ export function ConnectorConnectContainer({
   let Component =
     ConnectorClientComponents[name as keyof typeof ConnectorClientComponents]
 
-  if (!Component && connector?.authType === 'OAUTH2') {
+  if (!Component && connector?.auth_type === 'OAUTH2') {
     Component = makeNativeOauthConnectorClientComponent(
       preConnectRes.data.connect_input,
     )

--- a/apps/web/app/connect/MyConnections.client.tsx
+++ b/apps/web/app/connect/MyConnections.client.tsx
@@ -103,7 +103,7 @@ export function MyConnectionsClient(props: {
         return (
           <ConnectorConnectContainer
             connectorName={conn.connector_name as ConnectorName}
-            connector={{authType: 'OAUTH2'} as any}
+            connector={{auth_type: 'OAUTH2'} as any}
             connectorConfigId={conn.connector_config_id as Id['ccfg']}
             connectionId={conn.id as Id['conn']}>
             {renderCard}

--- a/apps/web/app/connect/page.tsx
+++ b/apps/web/app/connect/page.tsx
@@ -271,12 +271,12 @@ async function AddConnections({
   const availableToConnect = res.items.filter(
     (ccfg) =>
       // Allow custom connectors to be added multiple times
-      ccfg.connector?.authType === 'CUSTOM' ||
+      ccfg.connector?.auth_type === 'CUSTOM' ||
       // For non-custom connectors, only include if they don't already exist
       (!existingConnections.some(
         (conn) => conn.connector_config_id === ccfg.id,
       ) &&
-        ccfg.connector?.authType),
+        ccfg.connector?.auth_type),
   )
 
   if (!availableToConnect?.length || availableToConnect.length === 0) {

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -10369,7 +10369,7 @@
             },
             "additionalProperties": false
           },
-          "authType": {
+          "auth_type": {
             "type": "string",
             "enum": [
               "BASIC",
@@ -10406,7 +10406,7 @@
               ]
             }
           },
-          "hasOpenIntCredentials": {
+          "has_openint_credentials": {
             "type": "boolean"
           }
         },

--- a/packages/api-v1/__generated__/openapi.json
+++ b/packages/api-v1/__generated__/openapi.json
@@ -10405,6 +10405,9 @@
                 "scope"
               ]
             }
+          },
+          "hasOpenIntCredentials": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/packages/api-v1/__generated__/openapi.types.d.ts
+++ b/packages/api-v1/__generated__/openapi.types.d.ts
@@ -2605,6 +2605,7 @@ export interface components {
                 display_name?: string;
                 description?: string;
             }[];
+            hasOpenIntCredentials?: boolean;
         };
         /**
          * connector

--- a/packages/api-v1/__generated__/openapi.types.d.ts
+++ b/packages/api-v1/__generated__/openapi.types.d.ts
@@ -2598,14 +2598,14 @@ export interface components {
                 connect_output?: unknown;
             };
             /** @enum {string} */
-            authType?: "BASIC" | "OAUTH1" | "OAUTH2" | "OAUTH2CC" | "API_KEY" | "CUSTOM";
+            auth_type?: "BASIC" | "OAUTH1" | "OAUTH2" | "OAUTH2CC" | "API_KEY" | "CUSTOM";
             openint_scopes?: string[];
             scopes?: {
                 scope: string;
                 display_name?: string;
                 description?: string;
             }[];
-            hasOpenIntCredentials?: boolean;
+            has_openint_credentials?: boolean;
         };
         /**
          * connector

--- a/packages/api-v1/trpc/routers/connector.models.ts
+++ b/packages/api-v1/trpc/routers/connector.models.ts
@@ -36,7 +36,7 @@ export const zConnector = z.object({
       }),
     )
     .optional(),
-  hasOpenIntCredentials: z.boolean().optional(),
+  has_openint_credentials: z.boolean().optional(),
 })
 
 export {zConnectorName, type ConnectorName}
@@ -87,7 +87,7 @@ export const getConnectorModel = (
       def.metadata?.jsonDef?.auth.type === 'OAUTH2'
         ? def.metadata?.jsonDef?.auth.scopes
         : undefined,
-    hasOpenIntCredentials:
+    has_openint_credentials:
       getConnectorDefaultCredentials(def.name) !== undefined,
   }
 }

--- a/packages/api-v1/trpc/routers/connector.models.ts
+++ b/packages/api-v1/trpc/routers/connector.models.ts
@@ -6,10 +6,10 @@ import {defConnectors} from '@openint/all-connectors/connectors.def'
 import {zConnectorName} from '@openint/all-connectors/name'
 import {jsonSchemasByConnectorName} from '@openint/all-connectors/schemas'
 import {zConnectorSchemas} from '@openint/cdk'
+import {env, getConnectorDefaultCredentials} from '@openint/env'
 import {titleCase} from '@openint/util/string-utils'
 import {urlFromImage} from '@openint/util/url-utils'
 import {z} from '@openint/util/zod-utils'
-import {env} from '@openint/env'
 
 export const zConnector = z.object({
   name: z.string(),
@@ -36,6 +36,7 @@ export const zConnector = z.object({
       }),
     )
     .optional(),
+  hasOpenIntCredentials: z.boolean().optional(),
 })
 
 export {zConnectorName, type ConnectorName}
@@ -86,5 +87,7 @@ export const getConnectorModel = (
       def.metadata?.jsonDef?.auth.type === 'OAUTH2'
         ? def.metadata?.jsonDef?.auth.scopes
         : undefined,
+    hasOpenIntCredentials:
+      getConnectorDefaultCredentials(def.name) !== undefined,
   }
 }

--- a/packages/api-v1/trpc/routers/connector.models.ts
+++ b/packages/api-v1/trpc/routers/connector.models.ts
@@ -21,7 +21,7 @@ export const zConnector = z.object({
     .array(z.enum(['web', 'mobile', 'desktop', 'local', 'cloud']))
     .optional(),
   schemas: zConnectorSchemas.optional(),
-  authType: z
+  auth_type: z
     // custom should be considered to be default
     .enum(['BASIC', 'OAUTH1', 'OAUTH2', 'OAUTH2CC', 'API_KEY', 'CUSTOM'])
     .optional(),
@@ -70,7 +70,7 @@ export const getConnectorModel = (
         : logoUrl,
     stage: def.metadata?.stage,
     platforms: def.metadata?.platforms,
-    authType: def.metadata?.authType ?? 'CUSTOM',
+    auth_type: def.metadata?.authType ?? 'CUSTOM',
     // verticals: def.metadata?.verticals ?? ['other'],
     // authType: def.metadata?.authType,
 

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -36,7 +36,8 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
     }, {}) ?? {}
 
   const [useOpenIntCredentials, setUseOpenIntCredentials] = useState(
-    !formData?.client_id && !formData?.client_secret,
+    connector?.hasOpenIntCredentials &&
+      (!formData?.client_id || !formData?.client_secret),
   )
 
   const availableScopes: string[] = useOpenIntCredentials
@@ -70,20 +71,22 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <label
-          htmlFor="use-openint-credentials"
-          className="text-sm font-medium text-gray-700">
-          Use OpenInt {connector?.display_name} credentials
-        </label>
-        <Switch
-          id="use-openint-credentials"
-          checked={useOpenIntCredentials}
-          onCheckedChange={handleSwitchChange}
-        />
-      </div>
+      {connector?.hasOpenIntCredentials && (
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor="use-openint-credentials"
+            className="text-sm font-medium text-gray-700">
+            Use OpenInt {connector?.display_name} credentials
+          </label>
+          <Switch
+            id="use-openint-credentials"
+            checked={useOpenIntCredentials}
+            onCheckedChange={handleSwitchChange}
+          />
+        </div>
+      )}
 
-      {!useOpenIntCredentials && (
+      {(!connector?.hasOpenIntCredentials || !useOpenIntCredentials) && (
         <div className="space-y-2">
           <label
             htmlFor="client-id"

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -36,7 +36,7 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
     }, {}) ?? {}
 
   const [useOpenIntCredentials, setUseOpenIntCredentials] = useState(
-    connector?.hasOpenIntCredentials &&
+    connector?.has_openint_credentials &&
       (!formData?.client_id || !formData?.client_secret),
   )
 
@@ -71,7 +71,7 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
 
   return (
     <div className="space-y-4">
-      {connector?.hasOpenIntCredentials && (
+      {connector?.has_openint_credentials && (
         <div className="flex items-center justify-between">
           <label
             htmlFor="use-openint-credentials"
@@ -86,7 +86,7 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
         </div>
       )}
 
-      {(!connector?.hasOpenIntCredentials || !useOpenIntCredentials) && (
+      {(!connector?.has_openint_credentials || !useOpenIntCredentials) && (
         <div className="space-y-2">
           <label
             htmlFor="client-id"


### PR DESCRIPTION
## **User description**
…in ccfg sheet
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `hasOpenIntCredentials` to connector model/schema and update UI to conditionally show OpenInt credentials toggle.
> 
>   - **Behavior**:
>     - Added `hasOpenIntCredentials` boolean to connector model/schema to indicate availability of default OpenInt credentials.
>     - Updated `getConnectorModel` in `connector.models.ts` to set `hasOpenIntCredentials` based on default credentials.
>     - Modified `OAuthField` in `fields.tsx` to conditionally display OpenInt credentials toggle.
>     - Ensured `client_id` and `client_secret` fields are shown when default credentials are unavailable or not selected.
>   - **Renames**:
>     - Renamed `authType` to `auth_type` in `ConnectorConnect.client.tsx`, `MyConnections.client.tsx`, and `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for ed3789704f2e13d3a68e907d1fd381ed55a47f30. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Added a new `hasOpenIntCredentials` boolean property to the connector model and schema, indicating if default OpenInt credentials are available for a connector.
- Updated the `getConnectorModel` function to determine and set the `hasOpenIntCredentials` flag based on the presence of default credentials.
- Modified the `OAuthField` UI component to conditionally display the toggle for using OpenInt credentials only when such credentials exist.
- Improved the logic for displaying client_id and client_secret fields, ensuring they are shown when default credentials are not available or not selected.

This PR enhances both the backend connector model and the frontend UI to better handle the presence or absence of default OpenInt credentials. It ensures that users only see the toggle for using OpenInt credentials when such credentials exist, improving clarity and reducing confusion in the credential configuration process.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connector.models.ts</strong><dd><code>Add hasOpenIntCredentials flag to connector model and schema</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/api-v1/trpc/routers/connector.models.ts
<li>Added a new optional boolean property <code>hasOpenIntCredentials</code> to the <br><code>zConnector</code> schema.<br> <li> Updated the <code>getConnectorModel</code> function to set <code>hasOpenIntCredentials</code> <br>based on the presence of default credentials from <br><code>getConnectorDefaultCredentials</code>.<br> <li> Improved connector model to expose whether OpenInt default credentials <br>are available.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/554/files#diff-103e9a9f5585ee22bf3e8803714f4b95dacb6c9a313e639e73f2c965a6741f91">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fields.tsx</strong><dd><code>Conditionally render OpenInt credentials toggle in OAuthField UI</code></dd></summary>
<hr>

packages/ui-v1/components/schema-form/fields.tsx
<li>Updated the <code>OAuthField</code> component to use the new <code>hasOpenIntCredentials</code> <br>property from the connector model.<br> <li> Changed the logic for initializing and displaying the toggle for using <br>OpenInt credentials, hiding it if no default credentials are <br>available.<br> <li> Adjusted the rendering logic to show client_id/client_secret fields if <br>default credentials are absent or not selected.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/554/files#diff-6a466e07b487376cf35c0c7755e17c959e4f950ac5fd50118dc47889df4c0192">+17/-14</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
