### PR TITLE
Fix(api): Readding expired_at to connection 

### DIFF
--- a/apps/web/app/console/(authenticated)/connections/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connections/page.client.tsx
@@ -246,27 +246,6 @@ export function ConnectionsPage() {
                           </p>
                         </div>
                       </div>
-                      {selectedConnection.settings?.oauth?.last_fetched_at && (
-                        <div className="flex px-5 py-3">
-                          <h4 className="text-muted-foreground w-1/3 text-sm">
-                            Last Fetched
-                          </h4>
-                          <div className="flex w-2/3 items-center justify-between">
-                            <p className="text-sm font-medium">
-                              {formatIsoDateString(
-                                selectedConnection.settings.oauth
-                                  .last_fetched_at,
-                              )}
-                            </p>
-                            <p className="text-muted-foreground text-xs">
-                              {timeSince(
-                                selectedConnection.settings.oauth
-                                  .last_fetched_at,
-                              )}
-                            </p>
-                          </div>
-                        </div>
-                      )}
                     </div>
                   </section>
 
@@ -295,54 +274,47 @@ export function ConnectionsPage() {
                           </div>
                         </div>
 
-                        <div className="flex px-5 py-3">
-                          <h4 className="text-muted-foreground w-1/3 text-sm">
-                            Refresh Token
-                          </h4>
-                          <div className="w-2/3">
-                            <CopyID
-                              value={
-                                selectedConnection.settings.oauth.credentials
-                                  .refresh_token
-                              }
-                              width="100%"
-                              size="medium"
-                            />
+                        {selectedConnection.settings.oauth.credentials
+                          .refresh_token && (
+                          <div className="flex px-5 py-3">
+                            <h4 className="text-muted-foreground w-1/3 text-sm">
+                              Refresh Token
+                            </h4>
+                            <div className="w-2/3">
+                              <CopyID
+                                value={
+                                  selectedConnection.settings.oauth.credentials
+                                    .refresh_token
+                                }
+                                width="100%"
+                                size="medium"
+                              />
+                            </div>
                           </div>
-                        </div>
+                        )}
 
-                        <div className="px-5 py-3">
-                          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <div>
-                              <h4 className="text-muted-foreground mb-1 text-sm">
-                                Token Type
-                              </h4>
+                        {selectedConnection.settings.oauth.credentials
+                          .expires_at && (
+                          <div className="flex px-5 py-3">
+                            <h4 className="text-muted-foreground w-1/3 text-sm">
+                              Expires At
+                            </h4>
+                            <div className="flex w-2/3 items-center justify-between">
                               <p className="text-sm font-medium">
-                                {
+                                {formatIsoDateString(
                                   selectedConnection.settings.oauth.credentials
-                                    .token_type
-                                }
-                              </p>
-                            </div>
-                            <div>
-                              <h4 className="text-muted-foreground mb-1 text-sm">
-                                Expires In
-                              </h4>
-                              <p className="text-sm font-medium">
-                                {
-                                  selectedConnection.settings.oauth.credentials
-                                    .expires_in
-                                }
-                                s
+                                    .expires_at,
+                                )}
                               </p>
                             </div>
                           </div>
-                        </div>
+                        )}
 
                         <div className="px-5 py-3">
                           <h4 className="text-muted-foreground mb-1 text-sm">
-                            Scope
+                            Scopes
                           </h4>
+                          {/* TODO: use same component as in ccfg sheet  */}
                           <div className="grid grid-cols-2 gap-1.5 md:grid-cols-3">
                             {selectedConnection.settings.oauth.credentials.scope
                               .split(' ')
@@ -355,17 +327,6 @@ export function ConnectionsPage() {
                                 </span>
                               ))}
                           </div>
-                        </div>
-
-                        <div className="px-5 py-3">
-                          <h4 className="text-muted-foreground mb-1 text-sm">
-                            Expires At
-                          </h4>
-                          <p className="text-sm font-medium">
-                            {new Date(
-                              selectedConnection.settings.oauth.credentials.expires_at,
-                            ).toLocaleString()}
-                          </p>
                         </div>
                       </div>
                     </section>

--- a/connectors/cnext/auth-oauth2/createOAuth2ConnectorServer.ts
+++ b/connectors/cnext/auth-oauth2/createOAuth2ConnectorServer.ts
@@ -133,6 +133,9 @@ export function createOAuth2ConnectorServer<
               access_token: res.access_token,
               refresh_token: res.refresh_token,
               expires_in: res.expires_in,
+              expires_at: res.expires_in
+                ? new Date(Date.now() + res.expires_in * 1000).toISOString()
+                : undefined,
               scope: res.scope ?? client.joinScopes(config.oauth?.scopes ?? []),
               raw: res,
               token_type: undefined, // What should this be?
@@ -176,6 +179,9 @@ export function createOAuth2ConnectorServer<
                 access_token: res.access_token,
                 refresh_token: res.refresh_token,
                 expires_in: res.expires_in,
+                expires_at: res.expires_in
+                  ? new Date(Date.now() + res.expires_in * 1000).toISOString()
+                  : undefined,
                 raw: res,
                 scope:
                   res.scope ?? client.joinScopes(config.oauth?.scopes ?? []),


### PR DESCRIPTION
## **User description**
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reintroduces `expires_at` for OAuth2 connections, updating server logic, UI, and tests to ensure correct expiration handling.
> 
>   - **Behavior**:
>     - Reintroduces `expires_at` field in OAuth2 connection settings in `createOAuth2ConnectorServer.ts`.
>     - Calculates `expires_at` using `expires_in` and current time.
>     - Updates UI in `page.client.tsx` to conditionally display `expires_at` if available.
>   - **Tests**:
>     - Adds tests in `connect.spec.ts` to verify `expires_at` is set and in the future.
>     - Checks that `expires_at` matches `expires_in` plus current time with a small tolerance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for cf0b9efec653f2282daf311a45b7d50e7044c180. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Reintroduced the calculation and assignment of the `expires_at` field in OAuth2 connector server logic, ensuring it is set based on `expires_in` and the current time.
- Updated the connections UI to conditionally display the `Refresh Token` and `Expires At` fields only when present, and improved the formatting and structure of OAuth credential details.
- Added and enhanced tests to verify that `expires_at` is correctly set, is a future date, and matches the expected expiration time based on `expires_in`.

This PR restores and improves the handling of OAuth2 token expiration by ensuring the `expires_at` field is consistently calculated, returned, and displayed. It also strengthens test coverage to guarantee correct expiration logic, resulting in more robust and user-friendly connection management.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createOAuth2ConnectorServer.ts</strong><dd><code>Add expires_at calculation and return in OAuth2 connector server</code></dd></summary>
<hr>

connectors/cnext/auth-oauth2/createOAuth2ConnectorServer.ts
<li>Reintroduced calculation and assignment of the <code>expires_at</code> field in <br>OAuth2 credentials.<br> <li> <code>expires_at</code> is now set based on <code>expires_in</code> if available, using the <br>current time.<br> <li> Ensures that the OAuth2 connector server returns the <code>expires_at</code> value <br>as part of the credentials.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/557/files#diff-a69d6d4ebb60faacc51a090e8d6f0c30d29d02cc78e59720cd79886ec35c87fe">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>page.client.tsx</strong><dd><code>Improve OAuth credential display and conditional rendering in UI</code></dd></summary>
<hr>

apps/web/app/console/(authenticated)/connections/page.client.tsx
<li>Updated UI to conditionally display <code>Refresh Token</code> and <code>Expires At</code> only <br>if present in OAuth credentials.<br> <li> Improved display of the <code>Expires At</code> field to use formatted ISO date <br>strings.<br> <li> Removed redundant or duplicate rendering of <code>Expires At</code> and improved <br>section structure.<br> <li> Enhanced clarity and conditional rendering for OAuth credential <br>details.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/557/files#diff-334520e07cfb7ca64863a715fd07b3281054599780171f6c271326fce63f4dd1">+29/-68</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connect.spec.ts</strong><dd><code>Add and enhance tests for expires_at in OAuth credentials</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/api-v1/trpc/routers/connect.spec.ts
<li>Added tests to verify that <code>expires_at</code> is set and is a future date.<br> <li> Checked that <code>expires_at</code> matches <code>expires_in</code> plus the current time <br>within a small tolerance.<br> <li> Improved test robustness for OAuth credential expiration handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/557/files#diff-ac4d160f2559138c03046b1323c333faa1ae6a38f609c286cf2c5bc2fd767b27">+23/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
