### PR TITLE
oint-1173:  Move display name to advanced expand at the bottom of each ccfg and have placeholder be the current connector name pretty printed

### DIFF
--- a/apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
@@ -26,19 +26,6 @@ type ConnectorConfigDetailsProps = {
   | {connectorName: ConnectorName; connectorConfigId?: never}
 )
 
-/**
- * Handle advanced fields as an object to spread afterwards.
- * if not we cannot access/update correctly the field values.
- */
-type ConnectorConfigFormData = Omit<
-  Core['connector_config_insert'],
-  'display_name'
-> & {
-  advanced_fields?: {
-    display_name?: string
-  }
-}
-
 export function ConnectorConfigDetails({
   connectorConfigId,
   connectorName,
@@ -140,9 +127,11 @@ export function ConnectorConfigDetails({
     }),
   )
 
-  const handleSave = async (data: {formData: ConnectorConfigFormData}) => {
+  const handleSave = async (data: {
+    formData: Core['connector_config_insert']
+  }) => {
     const {
-      formData: {disabled, config = {}, advanced_fields = {}, ...rest},
+      formData: {display_name, disabled, config = {}, ...rest},
     } = data
 
     if (connectorConfigId) {
@@ -152,12 +141,12 @@ export function ConnectorConfigDetails({
       const updateCcfg = async () =>
         await updateConfig.mutateAsync({
           id: connectorConfigId,
+          display_name: display_name ?? undefined,
           disabled: disabled ?? undefined,
           config: {
             ...config,
             ...rest,
           },
-          ...advanced_fields,
         })
       if (hasOauthChanges && connectionCount > 0) {
         const confirmed = await confirmAlert({
@@ -173,12 +162,12 @@ export function ConnectorConfigDetails({
     } else {
       await createConfig.mutateAsync({
         connector_name: connectorName,
+        display_name,
         disabled,
         config: {
           ...config,
           ...rest,
         },
-        ...advanced_fields,
       })
     }
   }

--- a/apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
@@ -26,6 +26,19 @@ type ConnectorConfigDetailsProps = {
   | {connectorName: ConnectorName; connectorConfigId?: never}
 )
 
+/**
+ * Handle advanced fields as an object to spread afterwards.
+ * if not we cannot access/update correctly the field values.
+ */
+type ConnectorConfigFormData = Omit<
+  Core['connector_config_insert'],
+  'display_name'
+> & {
+  advanced_fields?: {
+    display_name?: string
+  }
+}
+
 export function ConnectorConfigDetails({
   connectorConfigId,
   connectorName,
@@ -127,11 +140,9 @@ export function ConnectorConfigDetails({
     }),
   )
 
-  const handleSave = async (data: {
-    formData: Core['connector_config_insert']
-  }) => {
+  const handleSave = async (data: {formData: ConnectorConfigFormData}) => {
     const {
-      formData: {display_name, disabled, config = {}, ...rest},
+      formData: {disabled, config = {}, advanced_fields = {}, ...rest},
     } = data
 
     if (connectorConfigId) {
@@ -141,12 +152,12 @@ export function ConnectorConfigDetails({
       const updateCcfg = async () =>
         await updateConfig.mutateAsync({
           id: connectorConfigId,
-          display_name: display_name ?? undefined,
           disabled: disabled ?? undefined,
           config: {
             ...config,
             ...rest,
           },
+          ...advanced_fields,
         })
       if (hasOauthChanges && connectionCount > 0) {
         const confirmed = await confirmAlert({
@@ -162,12 +173,12 @@ export function ConnectorConfigDetails({
     } else {
       await createConfig.mutateAsync({
         connector_name: connectorName,
-        display_name,
         disabled,
         config: {
           ...config,
           ...rest,
         },
+        ...advanced_fields,
       })
     }
   }

--- a/packages/api-v1/trpc/routers/connectorConfig.models.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.models.ts
@@ -67,7 +67,7 @@ export const advancedFieldsSchema = z.object({
     })
     .describe('Additional configuration options for this connector')
     .openapi({
-      title: 'Advanced Fields',
+      title: 'Advanced Settings',
       'ui:field': 'AdvancedField',
     }),
 })

--- a/packages/api-v1/trpc/routers/connectorConfig.models.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.models.ts
@@ -60,7 +60,7 @@ export const advancedFieldsSchema = z.object({
         .openapi({
           'ui:options': {
             title: 'Display Name',
-            placeholder: ' Enter Display Name',
+            placeholder: 'Enter Display Name',
           },
         }),
       // Add other advanced fields here as needed

--- a/packages/api-v1/trpc/routers/connectorConfig.models.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.models.ts
@@ -36,3 +36,38 @@ export type ConnectorConfig<
   T extends keyof ConnectorConfigExtensions = keyof ConnectorConfigExtensions,
 > = Core['connector_config_select'] &
   Partial<Pick<ConnectorConfigExtensions, T>>
+
+// Disabled field schema
+export const disabledSchema = z.object({
+  disabled: z
+    .boolean()
+    .describe(
+      'Disable connector config property, when disabled it will not be used in connect. Essentially a reversible soft-delete',
+    )
+    .openapi({
+      title: 'Disabled',
+      'ui:field': 'DisabledField',
+    }),
+})
+
+// Advanced fields schema
+export const advancedFieldsSchema = z.object({
+  advanced_fields: z
+    .object({
+      display_name: z
+        .string()
+        .optional()
+        .openapi({
+          'ui:options': {
+            title: 'Display Name',
+            placeholder: ' Enter Display Name',
+          },
+        }),
+      // Add other advanced fields here as needed
+    })
+    .describe('Additional configuration options for this connector')
+    .openapi({
+      title: 'Advanced Fields',
+      'ui:field': 'AdvancedField',
+    }),
+})

--- a/packages/api-v1/trpc/routers/connectorConfig.models.ts
+++ b/packages/api-v1/trpc/routers/connectorConfig.models.ts
@@ -46,7 +46,7 @@ export const disabledSchema = z.object({
     )
     .openapi({
       title: 'Disabled',
-      'ui:field': 'DisabledField',
+      'ui:field': 'ConnectorConfigDisabledField',
     }),
 })
 

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -156,7 +156,7 @@ export function OAuthField(props: FieldProps<OAuthConnectorConfig>) {
   )
 }
 
-export function DisabledField(props: FieldProps<boolean>) {
+export function ConnectorConfigDisabledField(props: FieldProps<boolean>) {
   const {formData, onChange, formContext} = props
   const {initialData, connector} = formContext as OAuthFormContext
 
@@ -247,7 +247,7 @@ export function DisabledField(props: FieldProps<boolean>) {
  */
 export const fields = {
   OAuthField,
-  DisabledField,
+  ConnectorConfigDisabledField,
   CredentialsField,
   AdvancedField,
   // Default fields we can override

--- a/packages/ui-v1/components/schema-form/fields.tsx
+++ b/packages/ui-v1/components/schema-form/fields.tsx
@@ -10,6 +10,7 @@ import {ConnectorBadges} from '../../domain-components/ConnectorDisplay'
 import {ConnectorScopes} from '../ConnectorScopes'
 import {CopyID} from '../CopyID'
 import {SecureInput} from '../SecureInput'
+import {AdvancedField} from './fields/AdvancedField'
 import {CredentialsField} from './fields/CredentialsField'
 
 interface Scope {
@@ -248,6 +249,7 @@ export const fields = {
   OAuthField,
   DisabledField,
   CredentialsField,
+  AdvancedField,
   // Default fields we can override
   // - ArrayField
   // - ArraySchemaField

--- a/packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
@@ -1,4 +1,4 @@
-import type {FieldProps} from '@rjsf/utils'
+import type {FieldProps, RJSFSchema} from '@rjsf/utils'
 
 import {Input, Label} from '@openint/shadcn/ui'
 import {
@@ -7,6 +7,14 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@openint/shadcn/ui/accordion'
+
+interface ExtendedJSONSchema extends RJSFSchema {
+  'ui:options'?: {
+    title?: string
+    placeholder?: string
+    [key: string]: unknown
+  }
+}
 
 function toTitleCase(str: string) {
   return str
@@ -18,7 +26,7 @@ function toTitleCase(str: string) {
  * AdvancedField is a field that collapses a section of the form.
  * It uses schema properties to render fields and handles them at the root level.
  */
-export function AdvancedField<T extends Record<string, unknown>>(
+export function AdvancedField<T extends Record<string, string | number>>(
   props: FieldProps<T>,
 ) {
   const {formData, onChange, schema} = props
@@ -37,8 +45,10 @@ export function AdvancedField<T extends Record<string, unknown>>(
         <AccordionContent className="space-y-4 pt-2">
           {schemaFields.map((fieldName) => {
             // Get schema for this field
-            const fieldSchema = schema.properties?.[String(fieldName)]
-            const fieldOptions = (fieldSchema as any)?.['ui:options']
+            const fieldSchema = schema.properties?.[
+              String(fieldName)
+            ] as ExtendedJSONSchema
+            const fieldOptions = fieldSchema?.['ui:options']
 
             return (
               <div key={String(fieldName)} className="space-y-2">
@@ -46,7 +56,7 @@ export function AdvancedField<T extends Record<string, unknown>>(
                   {fieldOptions?.title || toTitleCase(String(fieldName))}
                 </Label>
                 <Input
-                  value={formData?.[fieldName] as string}
+                  value={formData?.[fieldName]}
                   onChange={(e) => {
                     onChange({
                       ...formData,

--- a/packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
@@ -1,0 +1,65 @@
+import type {FieldProps} from '@rjsf/utils'
+
+import {Input, Label} from '@openint/shadcn/ui'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@openint/shadcn/ui/accordion'
+
+function toTitleCase(str: string) {
+  return str
+    .replace(/_/g, ' ')
+    .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1))
+}
+
+/**
+ * AdvancedField is a field that collapses a section of the form.
+ * It uses schema properties to render fields and handles them at the root level.
+ */
+export function AdvancedField<T extends Record<string, unknown>>(
+  props: FieldProps<T>,
+) {
+  const {formData, onChange, schema} = props
+
+  // Get field list from schema properties
+  const schemaFields = schema.properties ? Object.keys(schema.properties) : []
+
+  return (
+    <Accordion type="single" collapsible className="w-full">
+      <AccordionItem value="advanced-fields" className="border-none">
+        <AccordionTrigger className="py-2 hover:no-underline">
+          <h4 className="text-sm font-semibold">
+            {schema.title || 'Advanced Fields'}
+          </h4>
+        </AccordionTrigger>
+        <AccordionContent className="space-y-4 pt-2">
+          {schemaFields.map((fieldName) => {
+            // Get schema for this field
+            const fieldSchema = schema.properties?.[String(fieldName)]
+            const fieldOptions = (fieldSchema as any)?.['ui:options']
+
+            return (
+              <div key={String(fieldName)} className="space-y-2">
+                <Label className="text-sm font-medium text-gray-700">
+                  {fieldOptions?.title || toTitleCase(String(fieldName))}
+                </Label>
+                <Input
+                  value={formData?.[fieldName] as string}
+                  onChange={(e) => {
+                    onChange({
+                      ...formData,
+                      [fieldName]: e.target.value,
+                    } as T)
+                  }}
+                  placeholder={fieldOptions?.placeholder || ''}
+                />
+              </div>
+            )
+          })}
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
+++ b/packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
@@ -7,6 +7,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@openint/shadcn/ui/accordion'
+import {titleCase} from '@openint/util/string-utils'
 
 interface ExtendedJSONSchema extends RJSFSchema {
   'ui:options'?: {
@@ -14,12 +15,6 @@ interface ExtendedJSONSchema extends RJSFSchema {
     placeholder?: string
     [key: string]: unknown
   }
-}
-
-function toTitleCase(str: string) {
-  return str
-    .replace(/_/g, ' ')
-    .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1))
 }
 
 /**
@@ -53,7 +48,7 @@ export function AdvancedField<T extends Record<string, string | number>>(
             return (
               <div key={String(fieldName)} className="space-y-2">
                 <Label className="text-sm font-medium text-gray-700">
-                  {fieldOptions?.title || toTitleCase(String(fieldName))}
+                  {fieldOptions?.title || titleCase(String(fieldName))}
                 </Label>
                 <Input
                   value={formData?.[fieldName]}

--- a/packages/ui-v1/domain-components/ConnectorConfigForm.tsx
+++ b/packages/ui-v1/domain-components/ConnectorConfigForm.tsx
@@ -3,6 +3,8 @@
 import type {ConnectorConfig, Core} from '@openint/api-v1/models'
 import type {JSONSchemaFormRef} from '../components/schema-form'
 
+import {advancedFieldsSchema, disabledSchema} from '@openint/api-v1/models'
+import {zodToOas31Schema} from '@openint/util/schema'
 import {JSONSchemaForm} from '../components/schema-form'
 
 export type ConnectorConfigFormProps = {
@@ -50,11 +52,16 @@ export function ConnectorConfigForm({
     connectorConfig
       ? {
           ...connectorConfig.config,
-          display_name: connectorConfig.display_name ?? '',
+          advanced_fields: {
+            display_name: connectorConfig.display_name ?? '',
+          },
           disabled: connectorConfig.disabled ?? false,
         }
       : {}
   ) as Core['connector_config_insert']
+
+  const disabledField = zodToOas31Schema(disabledSchema)
+  const advancedFields = zodToOas31Schema(advancedFieldsSchema)
 
   /**
    * TODO: This is a temporary form schema, we need to move this to the connector config models.
@@ -64,19 +71,9 @@ export function ConnectorConfigForm({
   const formSchema = {
     type: 'object' as const,
     properties: {
-      disabled: {
-        type: 'boolean' as const,
-        title: 'Disabled',
-        description:
-          'When disabled it will not be used for connection portal. Essentially a reversible soft-delete',
-        'ui:field': 'DisabledField',
-      },
-      display_name: {
-        type: 'string' as const,
-        title: 'Display Name',
-        description: 'A friendly name for this connector configuration',
-      },
+      ...disabledField.properties,
       ...(configSchema?.['properties'] || {}),
+      ...(advancedFields?.properties || {}),
     },
   }
 
@@ -92,6 +89,7 @@ export function ConnectorConfigForm({
     scopes,
     initialData: connectorConfig,
     connector: connector ?? connectorConfig?.connector,
+    advancedFields: ['display_name'],
   }
 
   return (

--- a/packages/ui-v1/domain-components/ConnectorConfigForm.tsx
+++ b/packages/ui-v1/domain-components/ConnectorConfigForm.tsx
@@ -37,6 +37,15 @@ export type ConnectorConfigFormProps = {
     }
 )
 
+type ConnectorConfigFormData = Omit<
+  Core['connector_config_insert'],
+  'display_name'
+> & {
+  advanced_fields?: {
+    display_name?: string
+  }
+}
+
 /**
  * ConnectorConfigForm component that displays the configuration form for a specific connector
  */
@@ -63,6 +72,15 @@ export function ConnectorConfigForm({
   const disabledField = zodToOas31Schema(disabledSchema)
   const advancedFields = zodToOas31Schema(advancedFieldsSchema)
 
+  const handleSubmit = (data: {formData: ConnectorConfigFormData}) => {
+    const {advanced_fields, ...rest} = data.formData
+    onSubmit?.({
+      formData: {
+        ...rest,
+        ...advanced_fields,
+      },
+    })
+  }
   /**
    * TODO: This is a temporary form schema, we need to move this to the connector config models.
    * In the connector schemas we only have connector_config for this form, but we need to add the rest
@@ -95,13 +113,13 @@ export function ConnectorConfigForm({
     <div className="flex h-full flex-col">
       <div className="flex-1">
         <div className="flex h-full flex-col space-y-8 px-8 pb-24">
-          <JSONSchemaForm<Core['connector_config_insert']>
+          <JSONSchemaForm<ConnectorConfigFormData>
             jsonSchema={formSchema}
             formData={initialValues}
             formContext={formContext}
             formRef={formRef}
             changedFieldsRef={changedFieldsRef}
-            onSubmit={onSubmit}
+            onSubmit={handleSubmit}
           />
         </div>
       </div>

--- a/packages/ui-v1/domain-components/ConnectorConfigForm.tsx
+++ b/packages/ui-v1/domain-components/ConnectorConfigForm.tsx
@@ -89,7 +89,6 @@ export function ConnectorConfigForm({
     scopes,
     initialData: connectorConfig,
     connector: connector ?? connectorConfig?.connector,
-    advancedFields: ['display_name'],
   }
 
   return (


### PR DESCRIPTION
## **User description**
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move `display_name` to advanced fields in connector config forms, introducing `AdvancedField` component for collapsible sections and updating schemas and logic.
> 
>   - **Behavior**:
>     - Move `display_name` to `advanced_fields` in `ConnectorConfigDetails.tsx`, updating save logic and removing root-level usage.
>     - Add `AdvancedField` component in `AdvancedField.tsx` for collapsible form sections, supporting dynamic rendering.
>     - Update `ConnectorConfigForm.tsx` to integrate `advancedFieldsSchema` and handle nested `display_name`.
>   - **Schemas**:
>     - Add `advancedFieldsSchema` and `disabledSchema` in `connectorConfig.models.ts` for advanced fields handling.
>   - **Components**:
>     - Register `AdvancedField` in `fields.tsx` for schema form rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 67fdd0f7b543f900b03f5398dbfb379c59f2b65a. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Moved the `display_name` field from the root of connector config forms into a new collapsible "Advanced Fields" section, both in the UI and in the data model.
- Added a reusable `AdvancedField` component that dynamically renders advanced/collapsible fields in forms, supporting custom titles and placeholders.
- Updated the connector config form logic and schemas to use `advancedFieldsSchema` and `disabledSchema`, ensuring advanced fields are handled as a nested object.
- Refactored save logic and initial value handling to support the new advanced fields structure, removing direct usage of `display_name` at the root level.
- Registered the new `AdvancedField` component for use in schema-driven forms.

This PR restructures how advanced configuration fields, specifically `display_name`, are handled in connector config forms. By moving these fields into a dedicated collapsible section, the UI is streamlined and future advanced options can be easily added. The changes improve maintainability, user experience, and schema consistency.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConnectorConfigDetails.tsx</strong><dd><code>Move display_name to advanced_fields and update save logic in <br>ConnectorConfigDetails</code></dd></summary>
<hr>

apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
<li>Refactored form data handling to move <code>display_name</code> into a new <br><code>advanced_fields</code> object.<br> <li> Updated the <code>handleSave</code> logic to spread <code>advanced_fields</code> when creating <br>or updating connector configs.<br> <li> Removed direct usage of <code>display_name</code> at the root level in favor of <br>advanced fields.<br> <li> Improved type definitions for form data to support advanced fields.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/562/files#diff-8af17a3b84d9c6fc928e3c9e855cedd8236c7ac33dd9a1166c273c50c8bcf20e">+17/-6</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>connectorConfig.models.ts</strong><dd><code>Add advancedFieldsSchema and disabledSchema for connector config <br>models</code></dd></summary>
<hr>

packages/api-v1/trpc/routers/connectorConfig.models.ts
<li>Added <code>disabledSchema</code> for the disabled field with UI metadata.<br> <li> Introduced <code>advancedFieldsSchema</code> for advanced fields, including <br><code>display_name</code>, with OpenAPI and UI metadata.<br> <li> Provided structure for future advanced fields.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/562/files#diff-0a539ec0eb1373b8a374003d22c34589ef6903bc687df71b09734c895efe2297">+35/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fields.tsx</strong><dd><code>Register AdvancedField component for schema form rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui-v1/components/schema-form/fields.tsx
<li>Registered new <code>AdvancedField</code> component for use in schema forms.<br> <li> Enabled rendering of advanced/collapsible fields in forms.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/562/files#diff-6a466e07b487376cf35c0c7755e17c959e4f950ac5fd50118dc47889df4c0192">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AdvancedField.tsx</strong><dd><code>Add AdvancedField component for collapsible advanced fields in forms</code></dd></summary>
<hr>

packages/ui-v1/components/schema-form/fields/AdvancedField.tsx
<li>Added a new <code>AdvancedField</code> component to render collapsible advanced <br>fields sections.<br> <li> Dynamically renders fields based on schema properties.<br> <li> Supports custom titles and placeholders from schema metadata.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/562/files#diff-d6bbd69bf6b915f4e1aa347f6c8f666c75e54302194e664c059470f2d68810af">+65/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ConnectorConfigForm.tsx</strong><dd><code>Integrate advancedFieldsSchema and update form to use advanced_fields</code></dd></summary>
<hr>

packages/ui-v1/domain-components/ConnectorConfigForm.tsx
<li>Integrated <code>advancedFieldsSchema</code> and <code>disabledSchema</code> into the connector <br>config form.<br> <li> Updated initial values to nest <code>display_name</code> under <code>advanced_fields</code>.<br> <li> Modified form schema to include advanced fields and removed direct <br><code>display_name</code> field.<br> <li> Passed advanced fields metadata to the form.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/562/files#diff-863634b83839e7039ad94106136a6995fb2bbc34349f305cb49cc466fdf9c9d3">+11/-13</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
