### PR TITLE
oint-1282: Show OAuth reconnect only when ccfg has connections

### DIFF
--- a/apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
+++ b/apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
@@ -72,6 +72,8 @@ export function ConnectorConfigDetails({
     connectorConfig?.data?.connector?.display_name ??
     connector?.data?.display_name
 
+  const connectionCount = connectorConfig?.data?.connection_count ?? 0
+
   const onSuccessUpsert = () => {
     toast.success(
       `${displayName} ${connectorConfig?.data ? 'updated' : 'added'} successfully`,
@@ -146,7 +148,7 @@ export function ConnectorConfigDetails({
             ...rest,
           },
         })
-      if (hasOauthChanges) {
+      if (hasOauthChanges && connectionCount > 0) {
         const confirmed = await confirmAlert({
           title: 'OAuth Credentials Changed',
           description:


### PR DESCRIPTION
## **User description**
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Show OAuth reconnect confirmation only when there are active connections in `ConnectorConfigDetails.tsx`.
> 
>   - **Behavior**:
>     - In `ConnectorConfigDetails.tsx`, the OAuth reconnect confirmation is now shown only if `connectionCount` is greater than 0.
>     - This prevents unnecessary confirmation prompts when there are no active connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 9dce0c58790c8cde74aeb9cd4881cdf5a6648bdd. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Introduced a check for the number of active connections (`connectionCount`) before displaying the OAuth reconnect confirmation dialog.
- The confirmation prompt for OAuth credential changes is now only shown if there is at least one active connection, preventing unnecessary prompts when there are none.

This PR refines the user experience by ensuring that the OAuth reconnect confirmation dialog is only presented when relevant, i.e., when there are existing connections that would be affected by credential changes. This avoids confusion and streamlines the update process for connector configurations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConnectorConfigDetails.tsx</strong><dd><code>Show OAuth reconnect confirmation only when active connections exist</code></dd></summary>
<hr>

apps/web/app/console/(authenticated)/connector-config/ConnectorConfigDetails.tsx
<li>Added a <code>connectionCount</code> variable to track the number of active <br>connections.<br> <li> Modified the OAuth reconnect confirmation logic to only show the <br>prompt if there are active connections (<code>connectionCount > 0</code>).<br> <li> Prevents unnecessary confirmation dialogs when no connections exist.<br>


</details>
    

  </td>
  <td><a href="https://github.com/openintegrations/openint/pull/565/files#diff-8af17a3b84d9c6fc928e3c9e855cedd8236c7ac33dd9a1166c273c50c8bcf20e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
