### PR TITLE
Add timeout so ref is defined before showing the dialog for manual co…

### DIFF
--- a/apps/web/app/connect/ConnectOpWrapper.tsx
+++ b/apps/web/app/connect/ConnectOpWrapper.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import {ReactNode, useEffect, useState} from 'react'
+import type {ReactNode} from 'react'
+
+import {useEffect, useState} from 'react'
 import {useConnectContext} from './ConnectContextProvider'
 
 export function ConnectOpWrapper({children}: {children: ReactNode}) {
@@ -20,7 +22,7 @@ export function ConnectOpWrapper({children}: {children: ReactNode}) {
       {/* Background blur layer */}
       {/* Children that want to show on top of this should have z-20 or higher */}
       {isConnecting && (
-        <div className="absolute inset-0 z-10 bg-white/50 backdrop-blur-sm" />
+        <div className="absolute inset-0 z-10 z-50 bg-black/80" />
       )}
       {/* Content layer */}
       <div className="relative z-0">{children}</div>


### PR DESCRIPTION
…mponent
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add timeout in `ConnectorConnect.client.tsx` to ensure `ref.current` is defined before proceeding with connection operations.
> 
>   - **Behavior**:
>     - Adds timeout in `handleConnect` in `ConnectorConnect.client.tsx` to ensure `ref.current` is defined before proceeding, with a maximum wait of 1 second.
>     - Updates `connectFn` in `makeNativeOauthConnectorClientComponent` to set `isConnecting` state.
>   - **Styling**:
>     - Changes background blur layer styling in `ConnectOpWrapper.tsx`.
>   - **Refactoring**:
>     - Changes `ref` to `formRef` in `makeManualConnectorClientComponent` in `ConnectorClientComponents.client.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for c44efed728dc1e8750de9a68c2cb8f2000d4a253. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->