### PR TITLE
fix(api): checking connection only when we need to

### DIFF
--- a/packages/api-v1/trpc/routers/connection.ts
+++ b/packages/api-v1/trpc/routers/connection.ts
@@ -33,6 +33,7 @@ import {zConnectorName} from './connector.models'
 import {
   checkConnection,
   connectionCanBeChecked,
+  connectionExpired,
 } from './utils/connectionChecker'
 import {
   formatListResponse,
@@ -85,14 +86,20 @@ export const connectionRouter = router({
         })
       }
 
-      if (
+      const shouldCheckConnection =
         (input.refresh_policy === 'force' || input.refresh_policy === 'auto') &&
         connectionCanBeChecked(connection)
-      ) {
-        const {status, status_message} = await checkConnection(connection, ctx)
-        connection.status = status
-        connection.status_message = status_message ?? null
+
+      const isAutoRefreshNotExpired =
+        input.refresh_policy === 'auto' && !connectionExpired(connection)
+
+      if (!shouldCheckConnection || isAutoRefreshNotExpired) {
+        return expandConnection(connection!, input.expand)
       }
+
+      const {status, status_message} = await checkConnection(connection, ctx)
+      connection.status = status
+      connection.status_message = status_message ?? null
 
       return expandConnection(connection!, input.expand)
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize connection checking in `getConnection` in `connection.ts` by skipping checks when not expired and `refresh_policy` is 'auto'.
> 
>   - **Behavior**:
>     - In `connectionRouter` in `connection.ts`, optimize connection checking logic in `getConnection`.
>     - Skip `checkConnection` if `refresh_policy` is 'auto' and `connectionExpired()` returns false.
>   - **Functions**:
>     - Add `connectionExpired` to imports in `connection.ts`.
>     - Refactor `getConnection` to use `shouldCheckConnection` and `isAutoRefreshNotExpired` conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for e33607f4a7dc8766477ffb54929b7745f30a0f08. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->