### PR TITLE
Add required perms for stably to add comments to PRs/commits

### DIFF
--- a/.github/workflows/parallel-workflow-validate.yml
+++ b/.github/workflows/parallel-workflow-validate.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+  contents: write
+
 concurrency:
   group: validate-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This should fix the:
`Error: Resource not accessible by integration`

Seen in https://github.com/openintegrations/openint/actions/runs/15079899003/job/42394763780