### PR TITLE
Use afterCreateOrganizationUrl clerk prop to redirect on org creation

### DIFF
--- a/packages/console-auth/client.tsx
+++ b/packages/console-auth/client.tsx
@@ -73,6 +73,8 @@ export function OrganizationSwitcher() {
     <DynamicOrganizationSwitcher
       hidePersonal={true}
       appearance={{baseTheme: isDark ? darkTheme : undefined}}
+      // Redirect to the current page after creating an organization
+      afterCreateOrganizationUrl={() => '/console'}
     />
   )
 }

--- a/packages/console-auth/client.tsx
+++ b/packages/console-auth/client.tsx
@@ -13,6 +13,7 @@ import dynamic from 'next/dynamic'
 import React from 'react'
 import {resolveRoute} from '@openint/env'
 import {useTheme} from '@openint/ui-v1/components/ThemeProvider'
+import {resolveLinkPath} from '@openint/util/url-utils'
 
 export {
   ClerkProvider as AuthProvider,
@@ -74,7 +75,7 @@ export function OrganizationSwitcher() {
       hidePersonal={true}
       appearance={{baseTheme: isDark ? darkTheme : undefined}}
       // Redirect to the current page after creating an organization
-      afterCreateOrganizationUrl={() => '/console'}
+      afterCreateOrganizationUrl={() => resolveLinkPath('/console')}
     />
   )
 }

--- a/packages/console-auth/client.tsx
+++ b/packages/console-auth/client.tsx
@@ -13,7 +13,7 @@ import dynamic from 'next/dynamic'
 import React from 'react'
 import {resolveRoute} from '@openint/env'
 import {useTheme} from '@openint/ui-v1/components/ThemeProvider'
-import {resolveLinkPath} from '@openint/util/url-utils'
+import {resolveLinkPath} from '@/lib-common/Link'
 
 export {
   ClerkProvider as AuthProvider,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `afterCreateOrganizationUrl` prop to redirect to `/console` after organization creation in `OrganizationSwitcher`.
> 
>   - **Behavior**:
>     - Adds `afterCreateOrganizationUrl` prop to `DynamicOrganizationSwitcher` in `OrganizationSwitcher()` to redirect to `/console` after organization creation.
>   - **Imports**:
>     - Imports `resolveLinkPath` from `@/lib-common/Link` in `client.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for f699111af6cbce0100fa829c83bc503dfc217447. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->