### PR TITLE
oint-1312 date display in connections table

### DIFF
--- a/apps/web/app/console/(authenticated)/connections/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connections/page.client.tsx
@@ -50,10 +50,24 @@ const columns: Array<ColumnDef<ConnectionExpanded>> = [
   {
     header: 'Created At',
     accessorKey: 'created_at',
+    cell: ({row}) => {
+      return (
+        <span className="text-sm">
+          {formatIsoDateString(row.original.created_at)}
+        </span>
+      )
+    },
   },
   {
     header: 'Updated At',
     accessorKey: 'updated_at',
+    cell: ({row}) => {
+      return (
+        <span className="text-sm">
+          {formatIsoDateString(row.original.updated_at)}
+        </span>
+      )
+    },
   },
 ]
 

--- a/apps/web/app/console/(authenticated)/connections/page.client.tsx
+++ b/apps/web/app/console/(authenticated)/connections/page.client.tsx
@@ -64,7 +64,9 @@ const columns: Array<ColumnDef<ConnectionExpanded>> = [
     cell: ({row}) => {
       return (
         <span className="text-sm">
-          {formatIsoDateString(row.original.updated_at)}
+          {(row.original.updated_at &&
+            formatIsoDateString(row.original.updated_at)) ??
+            ''}
         </span>
       )
     },


### PR DESCRIPTION
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/1b420ca8-9945-4c5a-867a-256f22224496" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add custom cell renderer to format 'Created At' and 'Updated At' dates in connections table using `formatIsoDateString`.
> 
>   - **Behavior**:
>     - Custom cell renderer added for 'Created At' and 'Updated At' columns in `page.client.tsx`.
>     - Dates are now formatted using `formatIsoDateString` for consistent display.
>   - **Functions**:
>     - `formatIsoDateString` used to format `created_at` and `updated_at` fields in the connections table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 1838ea0e24b9a368c2c25da64bc7cd48c2d7bc89. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->