### PR TITLE
oint-1269 connection cell background fix

### DIFF
--- a/packages/ui-v1/domain-components/tables/ConnectionTableCell.tsx
+++ b/packages/ui-v1/domain-components/tables/ConnectionTableCell.tsx
@@ -44,7 +44,7 @@ export function ConnectionTableCell({
   const logo = (
     <div
       className={cn(
-        'bg-primary/15 relative flex h-[55px] w-[55px] items-center justify-center overflow-hidden rounded-sm',
+        'relative flex h-[55px] w-[55px] items-center justify-center overflow-hidden rounded-sm',
         'h-8 w-8',
       )}>
       {useLogo && logoUrl && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `bg-primary/15` class from logo container in `ConnectionTableCell.tsx` to fix background color issue.
> 
>   - **Visual Update**:
>     - Removed `bg-primary/15` class from the logo container div in `ConnectionTableCell.tsx`, affecting the background color of the connection cell logo.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 222bc7cdb153e5c54c5e83e48ffc4865eb986756. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->