### PR TITLE
oint-1341 scopes for OAuth2 integration

### DIFF
--- a/connectors/cnext/json-defs/github.ts
+++ b/connectors/cnext/json-defs/github.ts
@@ -12,11 +12,13 @@ export default {
     token_request_url: 'https://github.com/login/oauth/access_token',
     scope_separator: ' ',
     params_config: {},
+    required_scopes: ['read:user', 'user:email', 'repo', 'offline_access'],
     openint_default_scopes: [
       'read:user',
       'read:org',
       'read:project',
       'user:email',
+      'offline_access',
     ],
     openint_allowed_scopes: [
       'user',
@@ -24,6 +26,7 @@ export default {
       'read:org',
       'read:project',
       'user:email',
+      'offline_access',
     ],
     /**
      * We can review the available scopes here:
@@ -186,6 +189,11 @@ export default {
       {
         scope: 'read:audit_log',
         description: 'Read audit log data.',
+      },
+      {
+        scope: 'offline_access',
+        description:
+          'Allows the app to obtain refresh tokens, enabling long-term access to GitHub services even when the user is not actively using the application.',
       },
     ],
   },


### PR DESCRIPTION
- Introduced 'required_scopes' to define necessary permissions for GitHub OAuth2.
- Updated 'openint_default_scopes' and 'openint_allowed_scopes' to include 'offline_access'.
- Added description for 'offline_access' scope to clarify its purpose.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance GitHub OAuth2 integration by adding 'offline_access' to scopes in `github.ts`.
> 
>   - **OAuth2 Scopes**:
>     - Added `required_scopes` with `offline_access` in `github.ts`.
>     - Updated `openint_default_scopes` and `openint_allowed_scopes` to include `offline_access` in `github.ts`.
>     - Added description for `offline_access` scope in `github.ts` to explain its purpose for obtaining refresh tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=openintegrations%2Fopenint&utm_source=github&utm_medium=referral)<sup> for 1129cf1347a0fd5f26c00db8c6c8a9c82a77f83d. You can [customize](https://app.ellipsis.dev/openintegrations/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->